### PR TITLE
Issue #7, do not convert index into reflections hash using :to_s

### DIFF
--- a/lib/clowne/adapters/active_record/resolvers/association.rb
+++ b/lib/clowne/adapters/active_record/resolvers/association.rb
@@ -10,7 +10,7 @@ module Clowne
           class << self
             # rubocop: disable Metrics/ParameterLists
             def call(source, record, declaration, adapter:, params:, **_options)
-              reflection = source.class.reflections[declaration.name.to_s]
+              reflection = source.class.reflections[declaration.name]
 
               if reflection.nil?
                 raise UnknownAssociation,


### PR DESCRIPTION
declaration.name.to_s does not work as the reflections hash requires a symbol