### PR TITLE
Fix: Sequel adapter fail when clone a model without any association.

### DIFF
--- a/lib/clowne/adapters/sequel/operation.rb
+++ b/lib/clowne/adapters/sequel/operation.rb
@@ -7,7 +7,6 @@ module Clowne
     class Sequel # :nodoc: all
       class Operation < Clowne::Utils::Operation
         include Clowne::Ext::RecordKey
-
         def initialize(mapper)
           super
           @records = {}
@@ -23,6 +22,7 @@ module Clowne
 
         def to_record
           return @_record if defined?(@_record)
+          record_wrapper(@clone)
 
           @_record = @records[key(@clone)].to_model.tap do
             run_after_clone


### PR DESCRIPTION
# Summary
I was trying to use `clowne` with `sequel`. One of my models doesn't have any association. And when I tried to clone that model, I encountered this error:
```
NoMethodError:
       undefined method `to_model' for nil:NilClass
       Did you mean?  to_yaml
     # ./lib/clowne/adapters/sequel/operation.rb:27:in `to_record'
     # ./lib/clowne/utils/operation.rb:69:in `persist'
```
You can reproduce it by the integration test I wrote.

To fix that, I wrapped the cloned record before finding it in the `@records`