### PR TITLE
Use standard gem to avoid noisy rubocop releases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,11 @@
 require:
-- 'rubocop-md'
+  # add after moving docs to another tool
+  # - standard/cop/semantic_blocks
+  - 'rubocop-md'
+
+inherit_gem:
+  standard: config/base.yml
+
 AllCops:
   Exclude:
     - 'bin/**/*'
@@ -9,57 +15,10 @@ AllCops:
     - 'gemfiles/vendor/**/*'
     - 'clowne.gemspec'
   DisplayCopNames: true
-  StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Markdown:
   WarnInvalid: true
-
-Naming/AccessorMethodName:
-  Enabled: false
-
-Naming/ClassAndModuleCamelCase:
-  Exclude:
-    - 'spec/**/*.rb'
-
-Naming/UncommunicativeMethodParamName:
-  Enabled: false
-
-Naming/MemoizedInstanceVariableName:
-  Enabled: false
-
-Style/TrivialAccessors:
-  Enabled: false
-
-Metrics/LineLength:
-  Max: 100
-
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*.rb'
-    - 'README.md'
-
-Style/SymbolArray:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - 'spec/**/*.rb'
-    - 'Gemfile'
-    - 'Rakefile'
-    - '*.gemspec'
-    - 'CHANGELOG.md'
-    - 'README.md'
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*.rb'
-
-Bundler/OrderedGems:
-  Enabled: false
-
-Gemspec/OrderedDependencies:
-  Enabled: false
 
 Lint/Void:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: false
 language: ruby
+cache: bundler
 
 notifications:
   email: false
 
 before_install:
-  - gem update --system --no-prerelease
   - gem install bundler
 
 before_script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in clowne.gemspec
 gemspec
 
-gem 'pry-byebug', platform: :mri
+gem "pry-byebug", platform: :mri
 
-gem 'sqlite3', '~> 1.4.1', platform: :mri
-gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0', platform: :jruby
-gem 'jdbc-sqlite3', platform: :jruby
+gem "sqlite3", "~> 1.4.1", platform: :mri
+gem "activerecord-jdbcsqlite3-adapter", "~> 50.0", platform: :jruby
+gem "jdbc-sqlite3", platform: :jruby
 
-gem 'activerecord', '>= 5.0'
-gem 'sequel', '>= 5.0'
-gem 'simplecov'
+gem "activerecord", ">= 5.0"
+gem "sequel", ">= 5.0"
+gem "simplecov"
 
-local_gemfile = 'Gemfile.local'
+local_gemfile = "Gemfile.local"
 
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile)) # rubocop:disable Security/Eval

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem install clowne
 Or add this line to your application's Gemfile:
 
 ```ruby
-gem 'clowne'
+gem "clowne"
 ```
 
 ## Quick Start
@@ -87,7 +87,7 @@ Now you can use `UserCloner` to clone existing records:
 user = User.last
 # => <#User id: 1, login: 'clown', email: 'clown@circus.example.com'>
 
-operation = UserCloner.call(user, email: 'fake@example.com')
+operation = UserCloner.call(user, email: "fake@example.com")
 # => <#Clowne::Utils::Operation...>
 
 operation.to_record

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new

--- a/clowne.gemspec
+++ b/clowne.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'factory_bot', '~> 4.8'
-  spec.add_development_dependency 'rubocop', '~> 0.75'
-  spec.add_development_dependency 'rubocop-md', '~> 0.3'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.36'
+  spec.add_development_dependency 'rubocop', '~> 0.75.0'
+  spec.add_development_dependency 'rubocop-md', '~> 0.3.0'
+  spec.add_development_dependency 'rubocop-rspec', '~> 1.36.0'
+  spec.add_development_dependency 'standard', '~> 0.1.5'
 end

--- a/gemfiles/activerecord42.gemfile
+++ b/gemfiles/activerecord42.gemfile
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'activerecord', '~> 4.2'
-gem 'sequel', '>= 5.0'
-gem 'sqlite3', '~> 1.3.13'
+gem "activerecord", "~> 4.2"
+gem "sequel", ">= 5.0"
+gem "sqlite3", "~> 1.3.13"
 
-gemspec path: '..'
+gemspec path: ".."

--- a/gemfiles/jruby.gemfile
+++ b/gemfiles/jruby.gemfile
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'activerecord-jdbcsqlite3-adapter', '~> 50.0'
-gem 'jdbc-sqlite3'
-gem 'activerecord', '~> 5.0.0'
-gem 'sequel', '>= 5.0'
+gem "activerecord-jdbcsqlite3-adapter", "~> 50.0"
+gem "jdbc-sqlite3"
+gem "activerecord", "~> 5.0.0"
+gem "sequel", ">= 5.0"
 
-gemspec path: '..'
+gemspec path: ".."

--- a/gemfiles/railsmaster.gemfile
+++ b/gemfiles/railsmaster.gemfile
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'arel', github: 'rails/arel'
-gem 'rails', github: 'rails/rails'
-gem 'sequel', github: 'jeremyevans/sequel'
-gem 'sqlite3'
+gem "arel", github: "rails/arel"
+gem "rails", github: "rails/rails"
+gem "sequel", github: "jeremyevans/sequel"
+gem "sqlite3"
 
-gemspec path: '..'
+gemspec path: ".."

--- a/lib/clowne.rb
+++ b/lib/clowne.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
-require 'clowne/version'
-require 'clowne/declarations'
-require 'clowne/cloner'
+require "clowne/version"
+require "clowne/declarations"
+require "clowne/cloner"
 
-require 'clowne/adapters/base'
+require "clowne/adapters/base"
 
 # Declarative models cloning
 module Clowne
   # List of built-in adapters
   # rubocop:disable Layout/AlignHash
   ADAPTERS = {
-    base:          'Base',
-    active_record: 'ActiveRecord',
-    sequel:        'Sequel'
+    base:          "Base",
+    active_record: "ActiveRecord",
+    sequel:        "Sequel",
   }.freeze
   # rubocop:enable Layout/AlignHash
 
@@ -40,5 +40,5 @@ module Clowne
   end
 end
 
-require 'clowne/adapters/active_record' if defined?(::ActiveRecord)
-require 'clowne/adapters/sequel' if defined?(::Sequel)
+require "clowne/adapters/active_record" if defined?(::ActiveRecord)
+require "clowne/adapters/sequel" if defined?(::Sequel)

--- a/lib/clowne/adapters/active_record.rb
+++ b/lib/clowne/adapters/active_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/orm_ext'
+require "clowne/ext/orm_ext"
 
 module Clowne
   module Adapters
@@ -13,5 +13,5 @@ ActiveSupport.on_load(:active_record) do
   ::ActiveRecord::Base.extend Clowne::Ext::ORMExt
 end
 
-require 'clowne/adapters/active_record/associations'
-require 'clowne/adapters/active_record/resolvers/association'
+require "clowne/adapters/active_record/associations"
+require "clowne/adapters/active_record/resolvers/association"

--- a/lib/clowne/adapters/active_record/associations.rb
+++ b/lib/clowne/adapters/active_record/associations.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/active_record/associations/base'
-require 'clowne/adapters/active_record/associations/noop'
-require 'clowne/adapters/active_record/associations/belongs_to'
-require 'clowne/adapters/active_record/associations/has_one'
-require 'clowne/adapters/active_record/associations/has_many'
-require 'clowne/adapters/active_record/associations/has_and_belongs_to_many'
+require "clowne/adapters/active_record/associations/base"
+require "clowne/adapters/active_record/associations/noop"
+require "clowne/adapters/active_record/associations/belongs_to"
+require "clowne/adapters/active_record/associations/has_one"
+require "clowne/adapters/active_record/associations/has_many"
+require "clowne/adapters/active_record/associations/has_and_belongs_to_many"
 
 module Clowne
   module Adapters # :nodoc: all
@@ -15,7 +15,7 @@ module Clowne
           belongs_to: BelongsTo,
           has_one: HasOne,
           has_many: HasMany,
-          has_and_belongs_to_many: HABTM
+          has_and_belongs_to_many: HABTM,
         }.freeze
 
         # Returns an association cloner class for reflection

--- a/lib/clowne/adapters/active_record/associations/base.rb
+++ b/lib/clowne/adapters/active_record/associations/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/base/association'
+require "clowne/adapters/base/association"
 
 module Clowne
   module Adapters # :nodoc: all

--- a/lib/clowne/adapters/active_record/associations/belongs_to.rb
+++ b/lib/clowne/adapters/active_record/associations/belongs_to.rb
@@ -12,7 +12,7 @@ module Clowne
 
             unless declaration.scope.nil?
               warn(
-                '[Clowne] Belongs to association does not support scopes ' \
+                "[Clowne] Belongs to association does not support scopes " \
                 "(#{@association_name} for #{@source.class})"
               )
             end

--- a/lib/clowne/adapters/active_record/associations/has_one.rb
+++ b/lib/clowne/adapters/active_record/associations/has_one.rb
@@ -12,7 +12,7 @@ module Clowne
 
             unless declaration.scope.nil?
               warn(
-                '[Clowne] Has one association does not support scopes ' \
+                "[Clowne] Has one association does not support scopes " \
                 "(#{@association_name} for #{@source.class})"
               )
             end

--- a/lib/clowne/adapters/active_record/resolvers/association.rb
+++ b/lib/clowne/adapters/active_record/resolvers/association.rb
@@ -14,7 +14,7 @@ module Clowne
 
               if reflection.nil?
                 raise UnknownAssociation,
-                      "Association #{declaration.name} couldn't be found for #{source.class}"
+                  "Association #{declaration.name} couldn't be found for #{source.class}"
               end
 
               cloner_class = Associations.cloner_for(reflection)

--- a/lib/clowne/adapters/base.rb
+++ b/lib/clowne/adapters/base.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/registry'
+require "clowne/adapters/registry"
 
-require 'clowne/resolvers/init_as'
-require 'clowne/resolvers/nullify'
-require 'clowne/resolvers/finalize'
-require 'clowne/resolvers/after_persist'
-require 'clowne/resolvers/after_clone'
+require "clowne/resolvers/init_as"
+require "clowne/resolvers/nullify"
+require "clowne/resolvers/finalize"
+require "clowne/resolvers/after_persist"
+require "clowne/resolvers/after_clone"
 
 module Clowne
   module Adapters

--- a/lib/clowne/adapters/sequel.rb
+++ b/lib/clowne/adapters/sequel.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/orm_ext'
+require "clowne/ext/orm_ext"
 
 module Clowne
   module Adapters
@@ -21,9 +21,9 @@ end
 
 ::Sequel::Model.extend Clowne::Ext::ORMExt
 
-require 'clowne/adapters/sequel/operation'
-require 'clowne/adapters/sequel/associations'
-require 'clowne/adapters/sequel/copier'
-require 'clowne/adapters/sequel/record_wrapper'
-require 'clowne/adapters/sequel/resolvers/association'
-require 'clowne/adapters/sequel/resolvers/after_persist'
+require "clowne/adapters/sequel/operation"
+require "clowne/adapters/sequel/associations"
+require "clowne/adapters/sequel/copier"
+require "clowne/adapters/sequel/record_wrapper"
+require "clowne/adapters/sequel/resolvers/association"
+require "clowne/adapters/sequel/resolvers/after_persist"

--- a/lib/clowne/adapters/sequel/associations.rb
+++ b/lib/clowne/adapters/sequel/associations.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/sequel/associations/base'
-require 'clowne/adapters/sequel/associations/noop'
-require 'clowne/adapters/sequel/associations/one_to_one'
-require 'clowne/adapters/sequel/associations/one_to_many'
-require 'clowne/adapters/sequel/associations/many_to_many'
+require "clowne/adapters/sequel/associations/base"
+require "clowne/adapters/sequel/associations/noop"
+require "clowne/adapters/sequel/associations/one_to_one"
+require "clowne/adapters/sequel/associations/one_to_many"
+require "clowne/adapters/sequel/associations/many_to_many"
 
 module Clowne
   module Adapters # :nodoc: all
@@ -13,7 +13,7 @@ module Clowne
         SEQUEL_2_CLONER = {
           one_to_one: OneToOne,
           one_to_many: OneToMany,
-          many_to_many: ManyToMany
+          many_to_many: ManyToMany,
         }.freeze
 
         # Returns an association cloner class for reflection

--- a/lib/clowne/adapters/sequel/associations/base.rb
+++ b/lib/clowne/adapters/sequel/associations/base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/base/association'
+require "clowne/adapters/base/association"
 
 module Clowne
   module Adapters # :nodoc: all
@@ -10,7 +10,7 @@ module Clowne
           private
 
           def init_scope
-            @_init_scope ||= source.__send__([association_name, 'dataset'].join('_'))
+            @_init_scope ||= source.__send__([association_name, "dataset"].join("_"))
           end
 
           def record_wrapper(record)

--- a/lib/clowne/adapters/sequel/associations/many_to_many.rb
+++ b/lib/clowne/adapters/sequel/associations/many_to_many.rb
@@ -7,10 +7,10 @@ module Clowne
         class ManyToMany < Base
           def call(record)
             clones = with_scope
-                     .lazy
-                     .map(&method(:clone_one))
-                     .map(&method(:record_wrapper))
-                     .to_a
+              .lazy
+              .map(&method(:clone_one))
+              .map(&method(:record_wrapper))
+              .to_a
 
             record_wrapper(record).remember_assoc(:"#{association_name}_attributes", clones)
 

--- a/lib/clowne/adapters/sequel/associations/one_to_many.rb
+++ b/lib/clowne/adapters/sequel/associations/one_to_many.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/yield_self_then'
+require "clowne/ext/yield_self_then"
 
 using Clowne::Ext::YieldSelfThen
 

--- a/lib/clowne/adapters/sequel/associations/one_to_one.rb
+++ b/lib/clowne/adapters/sequel/associations/one_to_one.rb
@@ -9,7 +9,7 @@ module Clowne
             child = association
             return record unless child
 
-            warn '[Clowne] Has one association does not support scope' unless declaration.scope.nil?
+            warn "[Clowne] Has one association does not support scope" unless declaration.scope.nil?
 
             child_clone = clone_one(child)
             child_clone[:"#{reflection[:key]}"] = nil

--- a/lib/clowne/adapters/sequel/operation.rb
+++ b/lib/clowne/adapters/sequel/operation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/record_key'
+require "clowne/ext/record_key"
 
 module Clowne
   module Adapters

--- a/lib/clowne/adapters/sequel/resolvers/after_persist.rb
+++ b/lib/clowne/adapters/sequel/resolvers/after_persist.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/adapters/sequel/specifications/after_persist_does_not_support'
+require "clowne/adapters/sequel/specifications/after_persist_does_not_support"
 
 module Clowne
   module Adapters # :nodoc: all

--- a/lib/clowne/adapters/sequel/specifications/after_persist_does_not_support.rb
+++ b/lib/clowne/adapters/sequel/specifications/after_persist_does_not_support.rb
@@ -6,7 +6,7 @@ module Clowne
       module Specifications # :nodoc: all
         class AfterPersistDoesNotSupportException < StandardError
           def message
-            'Sequel adapter does not support after_persist callback'
+            "Sequel adapter does not support after_persist callback"
           end
         end
       end

--- a/lib/clowne/cloner.rb
+++ b/lib/clowne/cloner.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'clowne/planner'
-require 'clowne/dsl'
-require 'clowne/utils/options'
-require 'clowne/utils/params'
-require 'clowne/utils/operation'
+require "clowne/planner"
+require "clowne/dsl"
+require "clowne/utils/options"
+require "clowne/utils/params"
+require "clowne/utils/operation"
 
 module Clowne # :nodoc: all
   class UnprocessableSourceError < StandardError; end
@@ -45,12 +45,12 @@ module Clowne # :nodoc: all
 
       # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
       def call(object, **options)
-        raise(UnprocessableSourceError, 'Nil is not cloneable object') if object.nil?
+        raise(UnprocessableSourceError, "Nil is not cloneable object") if object.nil?
 
         options = Clowne::Utils::Options.new(options)
         current_adapter = current_adapter(options.adapter)
 
-        raise(ConfigurationError, 'Adapter is not defined') if current_adapter.nil?
+        raise(ConfigurationError, "Adapter is not defined") if current_adapter.nil?
 
         plan =
           if options.traits.empty?
@@ -79,7 +79,7 @@ module Clowne # :nodoc: all
 
       def plan_with_traits(ids, current_adapter: adapter)
         # Cache plans for combinations of traits
-        traits_id = ids.map(&:to_s).join(':')
+        traits_id = ids.map(&:to_s).join(":")
         return traits_plans[traits_id] if traits_plans.key?(traits_id)
 
         traits_plans[traits_id] = Clowne::Planner.compile(

--- a/lib/clowne/declarations.rb
+++ b/lib/clowne/declarations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'clowne/dsl'
-require 'clowne/utils/plan'
+require "clowne/dsl"
+require "clowne/utils/plan"
 
 module Clowne
   module Declarations # :nodoc:
@@ -23,12 +23,12 @@ module Clowne
   end
 end
 
-require 'clowne/declarations/base'
-require 'clowne/declarations/init_as'
-require 'clowne/declarations/exclude_association'
-require 'clowne/declarations/finalize'
-require 'clowne/declarations/include_association'
-require 'clowne/declarations/nullify'
-require 'clowne/declarations/trait'
-require 'clowne/declarations/after_persist'
-require 'clowne/declarations/after_clone'
+require "clowne/declarations/base"
+require "clowne/declarations/init_as"
+require "clowne/declarations/exclude_association"
+require "clowne/declarations/finalize"
+require "clowne/declarations/include_association"
+require "clowne/declarations/nullify"
+require "clowne/declarations/trait"
+require "clowne/declarations/after_persist"
+require "clowne/declarations/after_clone"

--- a/lib/clowne/declarations/after_clone.rb
+++ b/lib/clowne/declarations/after_clone.rb
@@ -6,7 +6,7 @@ module Clowne
       attr_reader :block
 
       def initialize
-        raise ArgumentError, 'Block is required for after_clone' unless block_given?
+        raise ArgumentError, "Block is required for after_clone" unless block_given?
 
         @block = Proc.new
       end

--- a/lib/clowne/declarations/after_persist.rb
+++ b/lib/clowne/declarations/after_persist.rb
@@ -6,7 +6,7 @@ module Clowne
       attr_reader :block
 
       def initialize
-        raise ArgumentError, 'Block is required for after_persist' unless block_given?
+        raise ArgumentError, "Block is required for after_persist" unless block_given?
 
         @block = Proc.new
       end

--- a/lib/clowne/declarations/finalize.rb
+++ b/lib/clowne/declarations/finalize.rb
@@ -6,7 +6,7 @@ module Clowne
       attr_reader :block
 
       def initialize
-        raise ArgumentError, 'Block is required for finalize' unless block_given?
+        raise ArgumentError, "Block is required for finalize" unless block_given?
 
         @block = Proc.new
       end

--- a/lib/clowne/declarations/include_association.rb
+++ b/lib/clowne/declarations/include_association.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/string_constantize'
+require "clowne/ext/string_constantize"
 
 module Clowne
   module Declarations

--- a/lib/clowne/declarations/init_as.rb
+++ b/lib/clowne/declarations/init_as.rb
@@ -6,7 +6,7 @@ module Clowne
       attr_reader :block
 
       def initialize
-        raise ArgumentError, 'Block is required for init_as' unless block_given?
+        raise ArgumentError, "Block is required for init_as" unless block_given?
 
         @block = Proc.new
       end

--- a/lib/clowne/declarations/nullify.rb
+++ b/lib/clowne/declarations/nullify.rb
@@ -6,7 +6,7 @@ module Clowne
       attr_reader :attributes
 
       def initialize(*attributes)
-        raise ArgumentError, 'At least one attribute required' if attributes.empty?
+        raise ArgumentError, "At least one attribute required" if attributes.empty?
 
         @attributes = attributes
       end

--- a/lib/clowne/ext/orm_ext.rb
+++ b/lib/clowne/ext/orm_ext.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/string_constantize'
+require "clowne/ext/string_constantize"
 
 module Clowne
   module Ext

--- a/lib/clowne/ext/record_key.rb
+++ b/lib/clowne/ext/record_key.rb
@@ -5,7 +5,7 @@ module Clowne
     module RecordKey # :nodoc: all
       def key(record)
         id = record.respond_to?(:id) && record.id ? record.id : record.__id__
-        [record.class.name, id].join('#')
+        [record.class.name, id].join("#")
       end
     end
   end

--- a/lib/clowne/ext/string_constantize.rb
+++ b/lib/clowne/ext/string_constantize.rb
@@ -6,7 +6,7 @@ module Clowne
     module StringConstantize
       refine String do
         def constantize
-          names = split('::')
+          names = split("::")
 
           return nil if names.empty?
 

--- a/lib/clowne/ext/yield_self_then.rb
+++ b/lib/clowne/ext/yield_self_then.rb
@@ -15,7 +15,7 @@ module Clowne
       end
 
       # See https://github.com/jruby/jruby/issues/5220
-      ::Object.include(Ext) if RUBY_PLATFORM =~ /java/i
+      ::Object.include(Ext) if RUBY_PLATFORM.match?(/java/i)
 
       refine Object do
         include Ext

--- a/lib/clowne/planner.rb
+++ b/lib/clowne/planner.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/utils/plan'
+require "clowne/utils/plan"
 
 module Clowne
   class Planner # :nodoc: all

--- a/lib/clowne/rspec.rb
+++ b/lib/clowne/rspec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'clowne/rspec/helpers'
-require 'clowne/rspec/clone_associations'
-require 'clowne/rspec/clone_association'
+require "clowne/rspec/helpers"
+require "clowne/rspec/clone_associations"
+require "clowne/rspec/clone_association"

--- a/lib/clowne/rspec/clone_association.rb
+++ b/lib/clowne/rspec/clone_association.rb
@@ -23,7 +23,7 @@ module Clowne
         # rubocop: disable Metrics/AbcSize
         def match(expected, _actual)
           @actual = plan.declarations
-                        .find { |key, decl| key == :association && decl.name == expected }
+            .find { |key, decl| key == :association && decl.name == expected }
 
           return false if @actual.nil?
 
@@ -60,10 +60,10 @@ module Clowne
             expected_params[param] = options.fetch(param, UNDEFINED)
           end
 
-          raise ArgumentError, 'Lambda scope is not supported' if
+          raise ArgumentError, "Lambda scope is not supported" if
             expected_params[:scope].is_a?(Proc)
 
-          raise ArgumentError, 'Lambda params is not supported' if
+          raise ArgumentError, "Lambda params is not supported" if
             expected_params[:params].is_a?(Proc)
         end
 

--- a/lib/clowne/rspec/clone_associations.rb
+++ b/lib/clowne/rspec/clone_associations.rb
@@ -9,8 +9,8 @@ module Clowne
 
         def convert_actual_to_an_array
           @actual = plan.declarations
-                        .select { |key, _| key == :association }
-                        .map { |_, decl| decl.name }
+            .select { |key, _| key == :association }
+            .map { |_, decl| decl.name }
         end
       end
     end

--- a/lib/clowne/rspec/helpers.rb
+++ b/lib/clowne/rspec/helpers.rb
@@ -27,7 +27,7 @@ module Clowne
       end
 
       def non_cloner_message
-        'expected a cloner to be passed to `expect(...)`, ' \
+        "expected a cloner to be passed to `expect(...)`, " \
         "but got #{actual_formatted}"
       end
     end

--- a/lib/clowne/utils/clone_mapper.rb
+++ b/lib/clowne/utils/clone_mapper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/record_key'
+require "clowne/ext/record_key"
 
 module Clowne
   module Utils

--- a/lib/clowne/utils/operation.rb
+++ b/lib/clowne/utils/operation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/utils/clone_mapper'
+require "clowne/utils/clone_mapper"
 
 module Clowne
   module Utils
@@ -74,12 +74,12 @@ module Clowne
       end
 
       def save
-        warn '[DEPRECATION] `save` is deprecated.  Please use `persist` instead.'
+        warn "[DEPRECATION] `save` is deprecated.  Please use `persist` instead."
         @clone.save
       end
 
       def save!
-        warn '[DEPRECATION] `save!` is deprecated.  Please use `persist!` instead.'
+        warn "[DEPRECATION] `save!` is deprecated.  Please use `persist!` instead."
         @clone.save!
       end
 

--- a/lib/clowne/utils/params.rb
+++ b/lib/clowne/utils/params.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'clowne/ext/lambda_as_proc'
+require "clowne/ext/lambda_as_proc"
 
 module Clowne
   module Utils

--- a/lib/clowne/version.rb
+++ b/lib/clowne/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Clowne
-  VERSION = '1.1.0'
+  VERSION = "1.1.0"
 end

--- a/spec/clowne/adapters/active_record/associations/belongs_to_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/belongs_to_spec.rb
@@ -1,9 +1,9 @@
 describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
-         :cleanup, adapter: :active_record do
+  :cleanup, adapter: :active_record do
   let(:adapter) { Clowne::Adapters::ActiveRecord.new }
   let(:topic) { create(:topic) }
   let(:source) { create(:post, topic: topic) }
-  let(:reflection) { AR::Post.reflections['topic'] }
+  let(:reflection) { AR::Post.reflections["topic"] }
   let(:record) { AR::Post.new }
   let(:scope) { {} }
   let(:declaration_params) { {} }
@@ -14,10 +14,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
 
   subject(:resolver) { described_class.new(reflection, source, declaration, adapter, params) }
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Utils::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'clones the topic without cloner' do
+    it "clones the topic without cloner" do
       expect(subject.topic).to be_new_record
       expect(subject.topic).to have_attributes(
         title: topic.title,
@@ -25,25 +25,25 @@ describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
       )
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:topic_cloner) do
         Class.new(Clowne::Cloner) do
           finalize do |_source, record, params|
-            record.title += params.fetch(:suffix, '-2')
-            record.description += ' (Cloned)'
+            record.title += params.fetch(:suffix, "-2")
+            record.description += " (Cloned)"
           end
 
           trait :mark_as_clone do
             finalize do |_source, record|
-              record.title += ' (Cloned)'
+              record.title += " (Cloned)"
             end
           end
         end
       end
 
-      let(:declaration_params) { { clone_with: topic_cloner } }
+      let(:declaration_params) { {clone_with: topic_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.topic).to be_new_record
         expect(subject.topic).to have_attributes(
           title: "#{topic.title}-2",
@@ -51,11 +51,11 @@ describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
         )
       end
 
-      context 'with params' do
-        let(:declaration_params) { { clone_with: topic_cloner, params: true } }
-        let(:params) { { suffix: '-new' } }
+      context "with params" do
+        let(:declaration_params) { {clone_with: topic_cloner, params: true} }
+        let(:params) { {suffix: "-new"} }
 
-        it 'pass params to child cloner' do
+        it "pass params to child cloner" do
           expect(subject.topic).to be_new_record
           expect(subject.topic).to have_attributes(
             title: "#{topic.title}-new",
@@ -64,10 +64,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
         end
       end
 
-      context 'with traits' do
-        let(:declaration_params) { { clone_with: topic_cloner, traits: :mark_as_clone } }
+      context "with traits" do
+        let(:declaration_params) { {clone_with: topic_cloner, traits: :mark_as_clone} }
 
-        it 'pass traits to child cloner' do
+        it "pass traits to child cloner" do
           expect(subject.topic).to be_new_record
           expect(subject.topic).to have_attributes(
             title: "#{topic.title}-2 (Cloned)",

--- a/spec/clowne/adapters/active_record/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_and_belongs_to_many_spec.rb
@@ -2,7 +2,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
   let(:adapter) { Clowne::Adapters::ActiveRecord.new }
   let(:source) { create(:post, :with_tags, tags_num: 2) }
   let(:record) { AR::Post.new }
-  let(:reflection) { AR::Post.reflections['tags'] }
+  let(:reflection) { AR::Post.reflections["tags"] }
   let(:scope) { {} }
   let(:declaration_params) { {} }
   let(:declaration) do
@@ -12,10 +12,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
 
   subject(:resolver) { described_class.new(reflection, source, declaration, adapter, params) }
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Utils::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'clones all the tags without cloner' do
+    it "clones all the tags without cloner" do
       expect(subject.tags.size).to eq 2
       expect(subject.tags.first).to have_attributes(
         value: source.tags.first.value
@@ -25,11 +25,11 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
       )
     end
 
-    context 'with scope' do
+    context "with scope" do
       let(:scope) { ->(params) { where(value: params[:with_tag]) if params[:with_tag] } }
-      let(:params) { { with_tag: source.tags.second.value } }
+      let(:params) { {with_tag: source.tags.second.value} }
 
-      it 'clones scoped children' do
+      it "clones scoped children" do
         expect(subject.tags.size).to eq 1
         expect(subject.tags.first).to have_attributes(
           value: source.tags.second.value
@@ -37,35 +37,35 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:tag_cloner) do
         Class.new(Clowne::Cloner) do
           finalize do |_source, record, params|
-            record.value += params.fetch(:suffix, '-2')
+            record.value += params.fetch(:suffix, "-2")
           end
 
           trait :mark_as_clone do
             finalize do |_source, record|
-              record.value += ' (Cloned)'
+              record.value += " (Cloned)"
             end
           end
         end
       end
 
-      let(:declaration_params) { { clone_with: tag_cloner } }
+      let(:declaration_params) { {clone_with: tag_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.tags.size).to eq 2
         expect(subject.tags.first).to have_attributes(
           value: "#{source.tags.first.value}-2"
         )
       end
 
-      context 'with params' do
-        let(:declaration_params) { { clone_with: tag_cloner, params: true } }
-        let(:params) { { suffix: '-new' } }
+      context "with params" do
+        let(:declaration_params) { {clone_with: tag_cloner, params: true} }
+        let(:params) { {suffix: "-new"} }
 
-        it 'pass params to child cloner' do
+        it "pass params to child cloner" do
           expect(subject.tags.size).to eq 2
           expect(subject.tags.first).to have_attributes(
             value: "#{source.tags.first.value}-new"
@@ -73,10 +73,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
         end
       end
 
-      context 'with traits' do
-        let(:declaration_params) { { clone_with: tag_cloner, traits: :mark_as_clone } }
+      context "with traits" do
+        let(:declaration_params) { {clone_with: tag_cloner, traits: :mark_as_clone} }
 
-        it 'pass traits to child cloner' do
+        it "pass traits to child cloner" do
           expect(subject.tags.size).to eq 2
           expect(subject.tags.first).to have_attributes(
             value: "#{source.tags.first.value}-2 (Cloned)"

--- a/spec/clowne/adapters/active_record/associations/has_many_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_many_spec.rb
@@ -2,7 +2,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
   let(:adapter) { Clowne::Adapters::ActiveRecord.new }
   let(:source) { create(:user, :with_posts, posts_num: 2) }
   let(:record) { AR::User.new }
-  let(:reflection) { AR::User.reflections['posts'] }
+  let(:reflection) { AR::User.reflections["posts"] }
   let(:scope) { {} }
   let(:declaration_params) { {} }
   let(:declaration) do
@@ -23,19 +23,19 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
     end
   end
 
-  after(:all) { AR.send(:remove_const, 'PostCloner') }
+  after(:all) { AR.send(:remove_const, "PostCloner") }
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Utils::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'infers default cloner from model name' do
+    it "infers default cloner from model name" do
       expect(subject.posts.size).to eq 2
       expect(subject.posts.first).to have_attributes(
         owner_id: nil,
@@ -51,11 +51,11 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
       )
     end
 
-    context 'with params' do
-      let(:declaration_params) { { params: true } }
-      let(:params) { { topic_id: 123 } }
+    context "with params" do
+      let(:declaration_params) { {params: true} }
+      let(:params) { {topic_id: 123} }
 
-      it 'pass params to child cloner' do
+      it "pass params to child cloner" do
         expect(subject.posts.size).to eq 2
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
@@ -68,12 +68,12 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
       end
     end
 
-    context 'with scope' do
-      context 'block scope' do
+    context "with scope" do
+      context "block scope" do
         let(:scope) { ->(params) { where(title: params[:title]) if params[:title] } }
-        let(:params) { { title: source.posts.first.title } }
+        let(:params) { {title: source.posts.first.title} }
 
-        it 'clones scoped children' do
+        it "clones scoped children" do
           expect(subject.posts.size).to eq 1
           expect(subject.posts.first).to have_attributes(
             owner_id: nil,
@@ -81,40 +81,40 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
           )
         end
 
-        context 'when block is no-op' do
+        context "when block is no-op" do
           let(:params) { {} }
 
-          it 'clones all children' do
+          it "clones all children" do
             expect(subject.posts.size).to eq 2
           end
         end
       end
 
-      context 'symbol scope' do
+      context "symbol scope" do
         let(:scope) { :alpha_first }
 
         let(:post1) { source.posts.first }
         let(:post2) { source.posts.second }
 
         before do
-          post1.update! title: 'Zadyza'
-          post2.update! title: 'Ta-dam'
+          post1.update! title: "Zadyza"
+          post2.update! title: "Ta-dam"
         end
 
-        it 'clones scoped children' do
+        it "clones scoped children" do
           expect(subject.posts.size).to eq 1
           expect(subject.posts.first).to have_attributes(
             owner_id: nil,
-            title: 'Ta-dam'
+            title: "Ta-dam"
           )
         end
       end
     end
 
-    context 'with traits' do
-      let(:declaration_params) { { traits: :mark_as_clone } }
+    context "with traits" do
+      let(:declaration_params) { {traits: :mark_as_clone} }
 
-      it 'pass traits to child cloner' do
+      it "pass traits to child cloner" do
         expect(subject.posts.size).to eq 2
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
@@ -129,10 +129,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:source) do
         create(:user).tap do |u|
-          create(:post, title: 'Some post', owner: u)
+          create(:post, title: "Some post", owner: u)
         end
       end
 
@@ -144,14 +144,14 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
         end
       end
 
-      let(:declaration_params) { { clone_with: post_cloner } }
+      let(:declaration_params) { {clone_with: post_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.posts.size).to eq 1
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
           topic_id: source.posts.first.topic_id,
-          title: 'Copy of Some post'
+          title: "Copy of Some post"
         )
       end
     end

--- a/spec/clowne/adapters/active_record/associations/has_one_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_one_spec.rb
@@ -5,7 +5,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
   let(:source) { post }
   let(:declaration_params) { {} }
   let(:record) { AR::Post.new }
-  let(:reflection) { AR::Post.reflections['image'] }
+  let(:reflection) { AR::Post.reflections["image"] }
   let(:association) { :image }
   let(:declaration) do
     Clowne::Declarations::IncludeAssociation.new(association, **declaration_params)
@@ -27,7 +27,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
@@ -41,7 +41,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
@@ -49,14 +49,14 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
   end
 
   after(:all) do
-    AR.send(:remove_const, 'ImageCloner')
-    AR.send(:remove_const, 'PreviewImageCloner')
+    AR.send(:remove_const, "ImageCloner")
+    AR.send(:remove_const, "PreviewImageCloner")
   end
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Utils::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'infers default cloner from model name' do
+    it "infers default cloner from model name" do
       expect(subject.image).to be_new_record
       expect(subject.image).to have_attributes(
         updated_at: nil,
@@ -73,11 +73,11 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
       )
     end
 
-    context 'with params' do
-      let(:declaration_params) { { params: true } }
-      let(:params) { { include_timestamps: true } }
+    context "with params" do
+      let(:declaration_params) { {params: true} }
+      let(:params) { {include_timestamps: true} }
 
-      it 'pass params to child cloner' do
+      it "pass params to child cloner" do
         expect(subject.image).to be_new_record
         expect(subject.image).to have_attributes(
           updated_at: nil,
@@ -95,10 +95,10 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
       end
     end
 
-    context 'with traits' do
-      let(:declaration_params) { { traits: [:mark_as_clone] } }
+    context "with traits" do
+      let(:declaration_params) { {traits: [:mark_as_clone]} }
 
-      it 'includes traits for self' do
+      it "includes traits for self" do
         expect(subject.image).to be_new_record
         expect(subject.image).to have_attributes(
           updated_at: nil,
@@ -116,7 +116,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:image_cloner) do
         Class.new(Clowne::Cloner) do
           finalize do |source, record, _params|
@@ -125,9 +125,9 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
         end
       end
 
-      let(:declaration_params) { { clone_with: image_cloner } }
+      let(:declaration_params) { {clone_with: image_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.image).to be_new_record
         expect(subject.image).to have_attributes(
           post_id: nil,

--- a/spec/clowne/adapters/active_record/resolvers/association_spec.rb
+++ b/spec/clowne/adapters/active_record/resolvers/association_spec.rb
@@ -7,13 +7,13 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
 
   subject { described_class.call(source, record, declaration, adapter: adapter, params: params) }
 
-  context 'with has_many' do
+  context "with has_many" do
     let(:association) { :posts }
     let(:source) { build_stubbed(:user) }
 
-    it 'uses HasMany resolver' do
+    it "uses HasMany resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::HasMany).to receive(:new).with(
-        AR::User.reflections['posts'], source, declaration, adapter, params
+        AR::User.reflections["posts"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)
@@ -24,13 +24,13 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
     end
   end
 
-  context 'with has_many through' do
+  context "with has_many through" do
     let(:association) { :images }
     let(:source) { build_stubbed(:user) }
 
-    it 'uses Noop resolver' do
+    it "uses Noop resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::Noop).to receive(:new).with(
-        AR::User.reflections['images'], source, declaration, adapter, params
+        AR::User.reflections["images"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)
@@ -41,12 +41,12 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
     end
   end
 
-  context 'with has_one' do
+  context "with has_one" do
     let(:association) { :image }
 
-    it 'uses HasOne resolver' do
+    it "uses HasOne resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::HasOne).to receive(:new).with(
-        AR::Post.reflections['image'], source, declaration, adapter, params
+        AR::Post.reflections["image"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)
@@ -57,12 +57,12 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
     end
   end
 
-  context 'with has_one through' do
+  context "with has_one through" do
     let(:association) { :preview_image }
 
-    it 'uses Noop resolver' do
+    it "uses Noop resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::Noop).to receive(:new).with(
-        AR::Post.reflections['preview_image'], source, declaration, adapter, params
+        AR::Post.reflections["preview_image"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)
@@ -73,12 +73,12 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
     end
   end
 
-  context 'with belongs_to' do
+  context "with belongs_to" do
     let(:association) { :topic }
 
-    it 'uses BelongsTo resolver' do
+    it "uses BelongsTo resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::BelongsTo).to receive(:new).with(
-        AR::Post.reflections['topic'], source, declaration, adapter, params
+        AR::Post.reflections["topic"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)
@@ -89,12 +89,12 @@ describe Clowne::Adapters::ActiveRecord::Resolvers::Association do
     end
   end
 
-  context 'with HABTM' do
+  context "with HABTM" do
     let(:association) { :tags }
 
-    it 'uses HABTM resolver' do
+    it "uses HABTM resolver" do
       expect(Clowne::Adapters::ActiveRecord::Associations::HABTM).to receive(:new).with(
-        AR::Post.reflections['tags'], source, declaration, adapter, params
+        AR::Post.reflections["tags"], source, declaration, adapter, params
       ) do
         double.tap do |resolver|
           expect(resolver).to receive(:call).with(record)

--- a/spec/clowne/adapters/active_record_spec.rb
+++ b/spec/clowne/adapters/active_record_spec.rb
@@ -5,7 +5,7 @@ describe Clowne::Adapters::ActiveRecord do
     Clowne::Utils::Operation.wrap { described_class.dup_record(record) }
   end
 
-  describe 'duplicate' do
+  describe "duplicate" do
     subject(:clone) { operation.to_record }
 
     it "get record's dup" do
@@ -16,10 +16,10 @@ describe Clowne::Adapters::ActiveRecord do
       expect(subject.updated_at).to be_nil
     end
 
-    describe 'mapper' do
+    describe "mapper" do
       subject(:mapper) { operation.mapper }
 
-      it 'saves mapping' do
+      it "saves mapping" do
         expect(mapper.clone_of(record)).to eq(clone)
       end
     end

--- a/spec/clowne/adapters/base/association_spec.rb
+++ b/spec/clowne/adapters/base/association_spec.rb
@@ -1,5 +1,5 @@
 describe Clowne::Adapters::Base::Association do
-  describe '.clone_one' do
+  describe ".clone_one" do
     let(:adapter) { double }
     let(:reflection) { double }
     let(:source) { double }
@@ -7,8 +7,8 @@ describe Clowne::Adapters::Base::Association do
     let(:child_cloner) { double }
     let(:scope) { {} }
     let(:custom_declaration_params) { {} }
-    let(:declaration_params) { { clone_with: child_cloner }.merge(custom_declaration_params) }
-    let(:params) { { post: { title: 'New post!' } } }
+    let(:declaration_params) { {clone_with: child_cloner}.merge(custom_declaration_params) }
+    let(:params) { {post: {title: "New post!"}} }
     let(:declaration) do
       Clowne::Declarations::IncludeAssociation.new(:posts, scope, **declaration_params)
     end
@@ -16,71 +16,71 @@ describe Clowne::Adapters::Base::Association do
 
     subject { association.clone_one(child) }
 
-    context 'when params option not defined' do
-      it 'clone without params' do
+    context "when params option not defined" do
+      it "clone without params" do
         expect(child_cloner).to receive(:call).with(child, adapter: adapter)
 
         subject
       end
     end
 
-    context 'when params option is false' do
-      let(:custom_declaration_params) { { params: false } }
+    context "when params option is false" do
+      let(:custom_declaration_params) { {params: false} }
 
-      it 'clone without params' do
+      it "clone without params" do
         expect(child_cloner).to receive(:call).with(child, adapter: adapter)
 
         subject
       end
     end
 
-    context 'when params option is true' do
-      let(:custom_declaration_params) { { params: true } }
+    context "when params option is true" do
+      let(:custom_declaration_params) { {params: true} }
 
-      it 'clone all params' do
+      it "clone all params" do
         expect(child_cloner).to receive(:call).with(child, params)
 
         subject
       end
     end
 
-    context 'when params option is a key' do
-      let(:custom_declaration_params) { { params: :post } }
+    context "when params option is a key" do
+      let(:custom_declaration_params) { {params: :post} }
 
-      it 'clone nested params' do
+      it "clone nested params" do
         expect(child_cloner).to receive(:call).with(child, params[:post])
 
         subject
       end
     end
 
-    context 'when params option is a block' do
-      let(:custom_declaration_params) { { params: ->(p) { p.merge(some_stuff: 'ಠᴗಠ') } } }
+    context "when params option is a block" do
+      let(:custom_declaration_params) { {params: ->(p) { p.merge(some_stuff: "ಠᴗಠ") }} }
 
-      it 'clone nested params' do
+      it "clone nested params" do
         expect(child_cloner).to receive(:call).with(
           child,
           adapter: adapter,
-          post: { title: 'New post!' },
-          some_stuff: 'ಠᴗಠ'
+          post: {title: "New post!"},
+          some_stuff: "ಠᴗಠ"
         )
 
         subject
       end
 
-      context 'with record' do
+      context "with record" do
         let(:custom_declaration_params) do
           {
-            params: ->(params, parent) { params.merge(some_stuff: 'ಠᴗಠ', parent: parent) }
+            params: ->(params, parent) { params.merge(some_stuff: "ಠᴗಠ", parent: parent) },
           }
         end
 
-        it 'clone nested params' do
+        it "clone nested params" do
           expect(child_cloner).to receive(:call).with(
             child,
             adapter: adapter,
-            post: { title: 'New post!' },
-            some_stuff: 'ಠᴗಠ',
+            post: {title: "New post!"},
+            some_stuff: "ಠᴗಠ",
             parent: source
           )
 

--- a/spec/clowne/adapters/registry_spec.rb
+++ b/spec/clowne/adapters/registry_spec.rb
@@ -1,7 +1,7 @@
 describe Clowne::Adapters::Registry do
   subject { described_class.new }
 
-  it 'works' do
+  it "works" do
     subject.append :a
     subject.unshift :b
     expect(subject.actions).to eq([:b, :a])
@@ -19,7 +19,7 @@ describe Clowne::Adapters::Registry do
     expect(subject.actions).to eq([:d, :e, :b, :c, :a, :f])
   end
 
-  it 'override if not unique' do
+  it "override if not unique" do
     subject.append :a
     subject.append :b
     subject.append :c
@@ -34,7 +34,7 @@ describe Clowne::Adapters::Registry do
     expect(subject.actions).to eq([:b, :c, :a])
   end
 
-  it 'raises if insert position is undefined' do
+  it "raises if insert position is undefined" do
     expect { subject.insert_before :a, :b }.to raise_error(/not found/)
 
     expect { subject.insert_after :a, :b }.to raise_error(/not found/)

--- a/spec/clowne/adapters/sequel/associations/many_to_many_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/many_to_many_spec.rb
@@ -1,6 +1,6 @@
 describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: :sequel do
   let(:adapter) { Clowne::Adapters::Sequel.new }
-  let(:source) { create('sequel:post', :with_tags, tags_num: 2) }
+  let(:source) { create("sequel:post", :with_tags, tags_num: 2) }
   let(:record) { Sequel::Post.new }
   let(:reflection) { Sequel::Post.association_reflections[:tags] }
   let(:scope) { {} }
@@ -12,10 +12,10 @@ describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: 
 
   subject(:resolver) { described_class.new(reflection, source, declaration, adapter, params) }
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Adapters::Sequel::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'clones all the tags withtout cloner' do
+    it "clones all the tags withtout cloner" do
       expect(subject.tags.size).to eq 2
       expect(subject.tags.first).to be_a(Sequel::Tag)
       expect(subject.tags.first.to_hash).to eq(
@@ -26,11 +26,11 @@ describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: 
       )
     end
 
-    context 'with scope' do
+    context "with scope" do
       let(:scope) { ->(params) { where(value: params[:with_tag]) if params[:with_tag] } }
-      let(:params) { { with_tag: source.tags.second.value } }
+      let(:params) { {with_tag: source.tags.second.value} }
 
-      it 'clones scoped children' do
+      it "clones scoped children" do
         expect(subject.tags.size).to eq 1
         expect(subject.tags.first).to have_attributes(
           value: source.tags.second.value
@@ -38,35 +38,35 @@ describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: 
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:tag_cloner) do
         Class.new(Clowne::Cloner) do
           finalize do |_source, record, params|
-            record.value += params.fetch(:suffix, '-2')
+            record.value += params.fetch(:suffix, "-2")
           end
 
           trait :mark_as_clone do
             finalize do |_source, record|
-              record.value += ' (Cloned)'
+              record.value += " (Cloned)"
             end
           end
         end
       end
 
-      let(:declaration_params) { { clone_with: tag_cloner } }
+      let(:declaration_params) { {clone_with: tag_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.tags.size).to eq 2
         expect(subject.tags.first).to have_attributes(
           value: "#{source.tags.first.value}-2"
         )
       end
 
-      context 'with params' do
-        let(:declaration_params) { { clone_with: tag_cloner, params: true } }
-        let(:params) { { suffix: '-new' } }
+      context "with params" do
+        let(:declaration_params) { {clone_with: tag_cloner, params: true} }
+        let(:params) { {suffix: "-new"} }
 
-        it 'pass params to child cloner' do
+        it "pass params to child cloner" do
           expect(subject.tags.size).to eq 2
           expect(subject.tags.first).to have_attributes(
             value: "#{source.tags.first.value}-new"
@@ -74,10 +74,10 @@ describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: 
         end
       end
 
-      context 'with traits' do
-        let(:declaration_params) { { clone_with: tag_cloner, traits: :mark_as_clone } }
+      context "with traits" do
+        let(:declaration_params) { {clone_with: tag_cloner, traits: :mark_as_clone} }
 
-        it 'pass traits to child cloner' do
+        it "pass traits to child cloner" do
           expect(subject.tags.size).to eq 2
           expect(subject.tags.first).to have_attributes(
             value: "#{source.tags.first.value}-2 (Cloned)"

--- a/spec/clowne/adapters/sequel/associations/one_to_many_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/one_to_many_spec.rb
@@ -1,6 +1,6 @@
 describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :sequel do
   let(:adapter) { Clowne::Adapters::Sequel.new }
-  let(:source) { create('sequel:user', :with_posts, posts_num: 2) }
+  let(:source) { create("sequel:user", :with_posts, posts_num: 2) }
   let(:record) { Sequel::User.new }
   let(:reflection) { Sequel::User.association_reflections[:posts] }
   let(:scope) { {} }
@@ -25,19 +25,19 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
     end
   end
 
-  after(:all) { Sequel.send(:remove_const, 'PostCloner') }
+  after(:all) { Sequel.send(:remove_const, "PostCloner") }
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Adapters::Sequel::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'infers default cloner from model name' do
+    it "infers default cloner from model name" do
       expect(subject.posts.size).to eq 2
       expect(subject.posts.first).to be_a(Sequel::Post)
       expect(subject.posts.first.image).to be_nil
@@ -55,12 +55,12 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       )
     end
 
-    context 'when post has image' do
+    context "when post has image" do
       let!(:images) do
-        source.posts.map { |post| create('sequel:image', post: post) }
+        source.posts.map { |post| create("sequel:image", post: post) }
       end
 
-      it 'infers nested image cloner' do
+      it "infers nested image cloner" do
         expect(subject.posts.first.image).to be_a(Sequel::Image)
         expect(subject.posts.first.image).to have_attributes(
           title: images.first.title
@@ -68,14 +68,14 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       end
     end
 
-    context 'when post has tags' do
+    context "when post has tags" do
       let!(:tags) do
         source.posts.map do |post|
-          create('sequel:tag').tap { |tag| tag.add_post(post) }
+          create("sequel:tag").tap { |tag| tag.add_post(post) }
         end
       end
 
-      it 'infers nested image cloner' do
+      it "infers nested image cloner" do
         post = subject.posts.first
         expect(post.tags.first).to be_a(Sequel::Tag)
         expect(post.tags.first).to have_attributes(
@@ -84,11 +84,11 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       end
     end
 
-    context 'with params' do
-      let(:declaration_params) { { params: true } }
-      let(:params) { { topic_id: 123 } }
+    context "with params" do
+      let(:declaration_params) { {params: true} }
+      let(:params) { {topic_id: 123} }
 
-      it 'pass params to child cloner' do
+      it "pass params to child cloner" do
         expect(subject.posts.size).to eq 2
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
@@ -101,12 +101,12 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       end
     end
 
-    context 'with scope' do
-      context 'block scope' do
+    context "with scope" do
+      context "block scope" do
         let(:scope) { ->(params) { where(title: params[:title]) if params[:title] } }
-        let(:params) { { title: source.posts.first.title } }
+        let(:params) { {title: source.posts.first.title} }
 
-        it 'clones scoped children' do
+        it "clones scoped children" do
           expect(subject.posts.size).to eq 1
           expect(subject.posts.first).to have_attributes(
             owner_id: nil,
@@ -114,40 +114,40 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
           )
         end
 
-        context 'when block is no-op' do
+        context "when block is no-op" do
           let(:params) { {} }
 
-          it 'clones all children' do
+          it "clones all children" do
             expect(subject.posts.size).to eq 2
           end
         end
       end
 
-      context 'symbol scope' do
+      context "symbol scope" do
         let(:scope) { :alpha_first }
 
         let(:post1) { source.posts.first }
         let(:post2) { source.posts.second }
 
         before do
-          post1.update title: 'Zadyza'
-          post2.update title: 'Ta-dam'
+          post1.update title: "Zadyza"
+          post2.update title: "Ta-dam"
         end
 
-        it 'clones scoped children' do
+        it "clones scoped children" do
           expect(subject.posts.size).to eq 1
           expect(subject.posts.first).to have_attributes(
             owner_id: nil,
-            title: 'Ta-dam'
+            title: "Ta-dam"
           )
         end
       end
     end
 
-    context 'with traits' do
-      let(:declaration_params) { { traits: :mark_as_clone } }
+    context "with traits" do
+      let(:declaration_params) { {traits: :mark_as_clone} }
 
-      it 'pass traits to child cloner' do
+      it "pass traits to child cloner" do
         expect(subject.posts.size).to eq 2
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
@@ -162,10 +162,10 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:source) do
-        create('sequel:user').tap do |user|
-          create('sequel:post', title: 'Some post', owner: user)
+        create("sequel:user").tap do |user|
+          create("sequel:post", title: "Some post", owner: user)
         end
       end
 
@@ -177,14 +177,14 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
         end
       end
 
-      let(:declaration_params) { { clone_with: post_cloner } }
+      let(:declaration_params) { {clone_with: post_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.posts.size).to eq 1
         expect(subject.posts.first).to have_attributes(
           owner_id: nil,
           topic_id: source.posts.first.topic_id,
-          title: 'Copy of Some post'
+          title: "Copy of Some post"
         )
       end
     end

--- a/spec/clowne/adapters/sequel/associations/one_to_one_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/one_to_one_spec.rb
@@ -1,7 +1,7 @@
 describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :sequel do
   let(:adapter) { Clowne::Adapters::Sequel.new }
-  let(:post) { create('sequel:post') }
-  let!(:image) { create('sequel:image', :with_preview_image, post: post) }
+  let(:post) { create("sequel:post") }
+  let!(:image) { create("sequel:image", :with_preview_image, post: post) }
   let(:source) { post }
   let(:declaration_params) { {} }
   let(:record) { Sequel::Post.new }
@@ -27,7 +27,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
@@ -41,7 +41,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' (Cloned)'
+            record.title = source.title + " (Cloned)"
           end
         end
       end
@@ -49,14 +49,14 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
   end
 
   after(:all) do
-    Sequel.send(:remove_const, 'ImageCloner')
-    Sequel.send(:remove_const, 'PreviewImageCloner')
+    Sequel.send(:remove_const, "ImageCloner")
+    Sequel.send(:remove_const, "PreviewImageCloner")
   end
 
-  describe '.call' do
+  describe ".call" do
     subject { Clowne::Adapters::Sequel::Operation.wrap { resolver.call(record) }.to_record }
 
-    it 'infers default cloner from model name' do
+    it "infers default cloner from model name" do
       expect(subject.image).to be_new
       expect(subject.image).to be_a(Sequel::Image)
       expect(subject.image.to_hash).to eq(
@@ -74,11 +74,11 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
       )
     end
 
-    context 'with params' do
-      let(:declaration_params) { { params: true } }
-      let(:params) { { include_timestamps: true } }
+    context "with params" do
+      let(:declaration_params) { {params: true} }
+      let(:params) { {include_timestamps: true} }
 
-      it 'pass params to child cloner' do
+      it "pass params to child cloner" do
         expect(subject.image).to be_new
         expect(subject.image).to have_attributes(
           post_id: nil,
@@ -94,10 +94,10 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
       end
     end
 
-    context 'with traits' do
-      let(:declaration_params) { { traits: [:mark_as_clone] } }
+    context "with traits" do
+      let(:declaration_params) { {traits: [:mark_as_clone]} }
 
-      it 'includes traits for self' do
+      it "includes traits for self" do
         expect(subject.image).to be_new
         expect(subject.image).to have_attributes(
           post_id: nil,
@@ -111,7 +111,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
       end
     end
 
-    context 'with custom cloner' do
+    context "with custom cloner" do
       let(:image_cloner) do
         Class.new(Clowne::Cloner) do
           finalize do |source, record, _params|
@@ -120,9 +120,9 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
         end
       end
 
-      let(:declaration_params) { { clone_with: image_cloner } }
+      let(:declaration_params) { {clone_with: image_cloner} }
 
-      it 'applies custom cloner' do
+      it "applies custom cloner" do
         expect(subject.image).to be_new
         expect(subject.image).to have_attributes(
           post_id: nil,

--- a/spec/clowne/adapters/sequel/resolvers/association_spec.rb
+++ b/spec/clowne/adapters/sequel/resolvers/association_spec.rb
@@ -3,16 +3,16 @@ describe Clowne::Adapters::Sequel::Resolvers::Association do
   let(:params) { double }
   let(:record) { double }
   let(:association) {}
-  let(:source) { build_stubbed('sequel:post') }
+  let(:source) { build_stubbed("sequel:post") }
   let(:declaration) { Clowne::Declarations::IncludeAssociation.new(association) }
 
   subject { described_class.call(source, record, declaration, adapter: adapter, params: params) }
 
-  context 'with one_to_many' do
+  context "with one_to_many" do
     let(:association) { :posts }
-    let(:source) { build_stubbed('sequel:user') }
+    let(:source) { build_stubbed("sequel:user") }
 
-    it 'uses OneToMany resolver' do
+    it "uses OneToMany resolver" do
       expect(Clowne::Adapters::Sequel::Associations::OneToMany).to receive(:new).with(
         Sequel::User.association_reflections[:posts], source, declaration, adapter, params
       ) do
@@ -25,10 +25,10 @@ describe Clowne::Adapters::Sequel::Resolvers::Association do
     end
   end
 
-  context 'with one_to_one' do
+  context "with one_to_one" do
     let(:association) { :image }
 
-    it 'uses OneToOne resolver' do
+    it "uses OneToOne resolver" do
       expect(Clowne::Adapters::Sequel::Associations::OneToOne).to receive(:new).with(
         Sequel::Post.association_reflections[:image], source, declaration, adapter, params
       ) do
@@ -41,10 +41,10 @@ describe Clowne::Adapters::Sequel::Resolvers::Association do
     end
   end
 
-  context 'with many_to_one' do
+  context "with many_to_one" do
     let(:association) { :topic }
 
-    it 'uses Noop resolver' do
+    it "uses Noop resolver" do
       expect(Clowne::Adapters::Sequel::Associations::Noop).to receive(:new).with(
         Sequel::Post.association_reflections[:topic], source, declaration, adapter, params
       ) do
@@ -57,10 +57,10 @@ describe Clowne::Adapters::Sequel::Resolvers::Association do
     end
   end
 
-  context 'with many_to_many' do
+  context "with many_to_many" do
     let(:association) { :tags }
 
-    it 'uses ManyToMany resolver' do
+    it "uses ManyToMany resolver" do
       expect(Clowne::Adapters::Sequel::Associations::ManyToMany).to receive(:new).with(
         Sequel::Post.association_reflections[:tags], source, declaration, adapter, params
       ) do
@@ -73,10 +73,10 @@ describe Clowne::Adapters::Sequel::Resolvers::Association do
     end
   end
 
-  context 'not clonable association' do
+  context "not clonable association" do
     let(:association) { :owner }
 
-    it 'does not call any resolver' do
+    it "does not call any resolver" do
       expect(Clowne::Adapters::Sequel::Associations::Noop).not_to receive(:new) do
         double.tap do |resolver|
           expect(resolver).to receive(:call)

--- a/spec/clowne/adapters/sequel_spec.rb
+++ b/spec/clowne/adapters/sequel_spec.rb
@@ -1,5 +1,5 @@
 describe Clowne::Adapters::Sequel do
-  let(:record) { create('sequel:post') }
+  let(:record) { create("sequel:post") }
 
   subject { described_class.dup_record(record) }
 

--- a/spec/clowne/cloner_spec.rb
+++ b/spec/clowne/cloner_spec.rb
@@ -4,8 +4,8 @@ describe Clowne::Cloner do
       adapter :active_record
 
       include_association :comments
-      include_association :posts, :some_scope, clone_with: 'AnotherClonerClass'
-      include_association :tags, clone_with: 'AnotherCloner2Class'
+      include_association :posts, :some_scope, clone_with: "AnotherClonerClass"
+      include_association :tags, clone_with: "AnotherCloner2Class"
 
       exclude_association :users
       include_association :users
@@ -33,26 +33,26 @@ describe Clowne::Cloner do
   let(:expected_plan) do
     [
       [:association, Clowne::Declarations::IncludeAssociation, {
-        name: :comments, scope: nil, options: {}
-      }],
+        name: :comments, scope: nil, options: {},
+      },],
       [:association, Clowne::Declarations::IncludeAssociation, {
         name: :posts,
         scope: :some_scope,
-        options: { clone_with: 'AnotherClonerClass' }
-      }],
+        options: {clone_with: "AnotherClonerClass"},
+      },],
       [:association, Clowne::Declarations::IncludeAssociation, {
         name: :tags,
         scope: nil,
-        options: { clone_with: 'AnotherCloner2Class' }
-      }],
-      [:nullify, Clowne::Declarations::Nullify, { attributes: %i[title description] }],
-      [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-      [:after_persist, Clowne::Declarations::AfterPersist, { block: proc { 2 + 2 } }]
+        options: {clone_with: "AnotherCloner2Class"},
+      },],
+      [:nullify, Clowne::Declarations::Nullify, {attributes: %i[title description]}],
+      [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+      [:after_persist, Clowne::Declarations::AfterPersist, {block: proc { 2 + 2 }}],
     ]
   end
 
-  describe '.default_plan' do
-    it 'compiles plan once', :aggregate_failures do
+  describe ".default_plan" do
+    it "compiles plan once", :aggregate_failures do
       plan = cloner.default_plan
 
       expect(plan.declarations).to match_declarations(expected_plan)
@@ -61,29 +61,29 @@ describe Clowne::Cloner do
     end
   end
 
-  describe '.plan_with_traits' do
+  describe ".plan_with_traits" do
     let(:expected_plan) do
       [
         [:association, Clowne::Declarations::IncludeAssociation, {
           name: :posts,
           scope: :some_scope,
-          options: { clone_with: 'AnotherClonerClass' }
-        }],
+          options: {clone_with: "AnotherClonerClass"},
+        },],
         [:association, Clowne::Declarations::IncludeAssociation, {
           name: :tags,
           scope: nil,
-          options: { clone_with: 'AnotherCloner2Class' }
-        }],
+          options: {clone_with: "AnotherCloner2Class"},
+        },],
         [:association, Clowne::Declarations::IncludeAssociation, {
-          name: :brands, scope: nil, options: {}
-        }],
-        [:nullify, Clowne::Declarations::Nullify, { attributes: %i[title description] }],
-        [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-        [:after_persist, Clowne::Declarations::AfterPersist, { block: proc { 2 + 2 } }]
+          name: :brands, scope: nil, options: {},
+        },],
+        [:nullify, Clowne::Declarations::Nullify, {attributes: %i[title description]}],
+        [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+        [:after_persist, Clowne::Declarations::AfterPersist, {block: proc { 2 + 2 }}],
       ]
     end
 
-    it 'compiles plan for traits once', :aggregate_failures do
+    it "compiles plan for traits once", :aggregate_failures do
       plan = cloner.plan_with_traits([:with_brands, :without_comments])
 
       expect(plan.declarations).to match_declarations(expected_plan)
@@ -92,23 +92,23 @@ describe Clowne::Cloner do
     end
   end
 
-  describe '.call' do
-    context 'when object is nil' do
+  describe ".call" do
+    context "when object is nil" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           adapter :base
         end
       end
 
-      it 'raise UnprocessableSourceError' do
+      it "raise UnprocessableSourceError" do
         expect { cloner.call(nil) }.to raise_error(
           Clowne::UnprocessableSourceError,
-          'Nil is not cloneable object'
+          "Nil is not cloneable object"
         )
       end
     end
 
-    context 'when trait is unknown' do
+    context "when trait is unknown" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           adapter :active_record
@@ -119,18 +119,18 @@ describe Clowne::Cloner do
         end
       end
 
-      it 'raise ConfigurationError' do
+      it "raise ConfigurationError" do
         expect { cloner.call(double, traits: [:without_comments]) }.to raise_error(
           Clowne::ConfigurationError,
-          'Trait not found: without_comments'
+          "Trait not found: without_comments"
         )
       end
     end
 
-    context 'with inline config' do
+    context "with inline config" do
       let(:source_class) { Struct.new(:name, :age) }
 
-      let(:source) { source_class.new('John', 28) }
+      let(:source) { source_class.new("John", 28) }
 
       let(:cloner) do
         Class.new(Clowne::Cloner) do
@@ -138,7 +138,7 @@ describe Clowne::Cloner do
         end
       end
 
-      it 'works', :aggregate_failures do
+      it "works", :aggregate_failures do
         inlined = cloner.call(source) do
           nullify :name
 
@@ -153,14 +153,14 @@ describe Clowne::Cloner do
         cloned = cloner.call(source)
 
         expect(cloned.to_record).to have_attributes(
-          name: 'John',
+          name: "John",
           age: 29
         )
       end
     end
   end
 
-  describe '.partial_apply', :aggregate_failures do
+  describe ".partial_apply", :aggregate_failures do
     let(:cloner) do
       Class.new(Clowne::Cloner) do
         adapter :active_record
@@ -181,31 +181,31 @@ describe Clowne::Cloner do
 
     let(:source_class) { Struct.new(:name, :age, :rating) }
 
-    let(:source) { source_class.new('John', 28, 99) }
+    let(:source) { source_class.new("John", 28, 99) }
 
-    specify 'one action' do
+    specify "one action" do
       cloned = cloner.partial_apply(:nullify, source).to_record
       expect(cloned.age).to eq 28
       expect(cloned.rating).to be_nil
-      expect(cloned.name).to eq 'John'
+      expect(cloned.name).to eq "John"
     end
 
-    specify 'with traits' do
+    specify "with traits" do
       cloned = cloner.partial_apply(:nullify, source, traits: :without_name).to_record
       expect(cloned.age).to eq 28
       expect(cloned.rating).to be_nil
       expect(cloned.name).to be_nil
     end
 
-    specify 'with params' do
+    specify "with params" do
       cloned = cloner.partial_apply(:finalize, source, coef: 3).to_record
       expect(cloned.age).to eq 84
       expect(cloned.rating).to eq 99
-      expect(cloned.name).to eq 'John'
+      expect(cloned.name).to eq "John"
     end
 
-    specify 'multiple actions' do
-      another = source_class.new('Jack', 33, 1)
+    specify "multiple actions" do
+      another = source_class.new("Jack", 33, 1)
       cloned = cloner.partial_apply(
         [:init_as, :finalize], source,
         traits: :copy, coef: 0.5, target: another
@@ -214,7 +214,7 @@ describe Clowne::Cloner do
       expect(cloned).to be_eql(another)
       expect(cloned.age).to eq 16.5
       expect(cloned.rating).to eq 1
-      expect(cloned.name).to eq 'Jack'
+      expect(cloned.name).to eq "Jack"
     end
   end
 end

--- a/spec/clowne/ext/string_constantize_spec.rb
+++ b/spec/clowne/ext/string_constantize_spec.rb
@@ -1,12 +1,12 @@
-require 'clowne/ext/string_constantize'
+require "clowne/ext/string_constantize"
 using Clowne::Ext::StringConstantize
 
 describe Clowne::Ext::StringConstantize do
-  it 'works', :aggregate_failures do
-    expect('::Clowne'.constantize).to eq Clowne
-    expect('Clowne'.constantize).to eq Clowne
-    expect('Clowne::Ext'.constantize).to eq Clowne::Ext
-    expect('CLownelqw'.constantize).to be_nil
-    expect(''.constantize).to be_nil
+  it "works", :aggregate_failures do
+    expect("::Clowne".constantize).to eq Clowne
+    expect("Clowne".constantize).to eq Clowne
+    expect("Clowne::Ext".constantize).to eq Clowne::Ext
+    expect("CLownelqw".constantize).to be_nil
+    expect("".constantize).to be_nil
   end
 end

--- a/spec/clowne/integrations/active_record_belongs_to_spec.rb
+++ b/spec/clowne/integrations/active_record_belongs_to_spec.rb
@@ -1,4 +1,4 @@
-describe 'AR belongs to loop', :cleanup, adapter: :active_record, transactional: :active_record do
+describe "AR belongs to loop", :cleanup, adapter: :active_record, transactional: :active_record do
   before(:all) do
     module AR
       class PostCloner < Clowne::Cloner
@@ -21,11 +21,11 @@ describe 'AR belongs to loop', :cleanup, adapter: :active_record, transactional:
     end
   end
 
-  let!(:post) { create(:post, title: 'TeamCity', topic: topic, image: image) }
-  let(:image) { create(:image, title: 'Manager') }
+  let!(:post) { create(:post, title: "TeamCity", topic: topic, image: image) }
+  let(:image) { create(:image, title: "Manager") }
   let(:topic) { create(:topic, image: image) }
 
-  it 'clone loop' do
+  it "clone loop" do
     expect(AR::Topic.count).to eq(1)
     expect(AR::Post.count).to eq(1)
     expect(AR::Image.count).to eq(1)

--- a/spec/clowne/integrations/active_record_dsl_spec.rb
+++ b/spec/clowne/integrations/active_record_dsl_spec.rb
@@ -1,10 +1,10 @@
-require 'clowne/adapters/active_record/dsl'
+require "clowne/adapters/active_record/dsl"
 
-describe 'AR DSl', :cleandb do
+describe "AR DSl", :cleandb do
   before(:all) do
-    module AR_DSL
+    module ArDSL
       class User < ActiveRecord::Base
-        has_many :posts, class_name: 'AR_DSL::Post', foreign_key: :owner_id
+        has_many :posts, class_name: "ArDSL::Post", foreign_key: :owner_id
 
         clowne_config do
           include_association :posts
@@ -20,8 +20,8 @@ describe 'AR DSl', :cleandb do
       end
 
       class Post < ActiveRecord::Base
-        has_one :image, class_name: 'AR_DSL::Image'
-        belongs_to :owner, class_name: 'AR_DSL::User'
+        has_one :image, class_name: "ArDSL::Image"
+        belongs_to :owner, class_name: "ArDSL::User"
 
         clowne_config do
           include_association :image
@@ -39,51 +39,51 @@ describe 'AR DSl', :cleandb do
       end
 
       class Image < ActiveRecord::Base
-        belongs_to :post, class_name: 'AR_DSL::Post'
+        belongs_to :post, class_name: "ArDSL::Post"
       end
     end
   end
 
   after(:all) do
     %w[User Admin Post DraftPost Image].each do |klass|
-      AR_DSL.send(:remove_const, klass)
+      ArDSL.send(:remove_const, klass)
     end
   end
 
-  let!(:user) { AR_DSL::User.create!(name: 'Jack Sparrow', email: 'sparrow@black.pearl.test') }
+  let!(:user) { ArDSL::User.create!(name: "Jack Sparrow", email: "sparrow@black.pearl.test") }
 
   let!(:post) do
-    AR_DSL::Post.create!(
-      owner: user, topic_id: 123, title: 'Pirates of XXI century',
+    ArDSL::Post.create!(
+      owner: user, topic_id: 123, title: "Pirates of XXI century",
       contents: "Let's rock!"
     )
   end
 
   let!(:draft_post) do
-    AR_DSL::DraftPost.create!(owner: user, topic_id: nil, title: '[wip]', contents: 'TBD')
+    ArDSL::DraftPost.create!(owner: user, topic_id: nil, title: "[wip]", contents: "TBD")
   end
 
-  let!(:image) { AR_DSL::Image.create!(post: post, title: 'Union Black') }
-  let!(:draft_image) { AR_DSL::Image.create!(post: draft_post, title: 'Draf of Union Black') }
+  let!(:image) { ArDSL::Image.create!(post: post, title: "Union Black") }
+  let!(:draft_image) { ArDSL::Image.create!(post: draft_post, title: "Draf of Union Black") }
 
-  describe '#clowne' do
-    it 'uses in-model config' do
-      cloned_post = post.clowne(title: 'New Post').to_record
+  describe "#clowne" do
+    it "uses in-model config" do
+      cloned_post = post.clowne(title: "New Post").to_record
 
-      expect(cloned_post.title).to eq 'New Post'
+      expect(cloned_post.title).to eq "New Post"
       expect(cloned_post.image).not_to be_nil
-      expect(cloned_post.image.title).to eq 'Union Black'
+      expect(cloned_post.image.title).to eq "Union Black"
     end
 
-    it 'works with inherit: false' do
-      cloned_post = draft_post.clowne(title: 'New Post').to_record
+    it "works with inherit: false" do
+      cloned_post = draft_post.clowne(title: "New Post").to_record
 
-      expect(cloned_post.title).to eq '[wip]'
+      expect(cloned_post.title).to eq "[wip]"
       expect(cloned_post.image).to be_nil
     end
 
-    it 'works with inheritance' do
-      admin = AR_DSL::Admin.find(user.id)
+    it "works with inheritance" do
+      admin = ArDSL::Admin.find(user.id)
 
       cloned_admin = admin.clowne.to_record
       cloned_user = user.clowne.to_record
@@ -93,15 +93,15 @@ describe 'AR DSl', :cleandb do
 
       expect(cloned_admin.email).to be_nil
       expect(cloned_admin.posts.size).to eq 1
-      expect(cloned_admin.posts.first.title).to eq 'Clone of Pirates of XXI century'
+      expect(cloned_admin.posts.first.title).to eq "Clone of Pirates of XXI century"
     end
 
-    it 'works with inline config' do
-      cloned_post = draft_post.clowne(title: 'New Post') do
+    it "works with inline config" do
+      cloned_post = draft_post.clowne(title: "New Post") do
         nullify :owner_id
       end.to_record
 
-      expect(cloned_post.title).to eq '[wip]'
+      expect(cloned_post.title).to eq "[wip]"
       expect(cloned_post.image).to be_nil
       expect(cloned_post.owner_id).to be_nil
     end

--- a/spec/clowne/integrations/active_record_spec.rb
+++ b/spec/clowne/integrations/active_record_spec.rb
@@ -1,4 +1,4 @@
-describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active_record do
+describe "AR adapter", :cleanup, adapter: :active_record, transactional: :active_record do
   before(:all) do
     module AR
       class ImgCloner < Clowne::Cloner
@@ -18,14 +18,14 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
       end
 
       class PostCloner < BasePostCloner
-        include_association :image, clone_with: 'AR::ImgCloner',
+        include_association :image, clone_with: "AR::ImgCloner",
                                     traits: %i[with_preview_image nullify_title],
                                     params: true
         include_association :tags, ->(params) { where(value: params[:tags]) if params[:tags] }
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' Super!'
+            record.title = source.title + " Super!"
           end
         end
 
@@ -51,11 +51,11 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
     end
   end
 
-  let!(:image) { create(:image, title: 'Manager') }
+  let!(:image) { create(:image, title: "Manager") }
   let!(:preview_image) do
-    create(:preview_image, some_stuff: 'This is preview about my life', image: image)
+    create(:preview_image, some_stuff: "This is preview about my life", image: image)
   end
-  let!(:post) { create(:post, title: 'TeamCity', image: image) }
+  let!(:post) { create(:post, title: "TeamCity", image: image) }
   let(:topic) { post.topic }
 
   let!(:tags) do
@@ -64,7 +64,7 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
     end
   end
 
-  it 'clone all stuff' do
+  it "clone all stuff" do
     expect(AR::Topic.count).to eq(1)
     expect(AR::Post.count).to eq(1)
     expect(AR::Tag.count).to eq(3)
@@ -75,8 +75,8 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
       post,
       traits: :mark_as_clone,
       tags: %w[CI CD],
-      post_contents: 'THIS IS CLONE! (☉_☉)',
-      preview_image: { suffix: ' - 2' }
+      post_contents: "THIS IS CLONE! (☉_☉)",
+      preview_image: {suffix: " - 2"}
     ).to_record
 
     cloned.save!
@@ -89,8 +89,8 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
 
     # post
     expect(cloned).to be_a(AR::Post)
-    expect(cloned.title).to eq('TeamCity Super!')
-    expect(cloned.contents).to eq('THIS IS CLONE! (☉_☉)')
+    expect(cloned.title).to eq("TeamCity Super!")
+    expect(cloned.contents).to eq("THIS IS CLONE! (☉_☉)")
 
     # image
     image_clone = cloned.image
@@ -100,16 +100,16 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
 
     # preview_image
     preview_image_clone = image_clone.preview_image
-    expect(preview_image_clone.some_stuff).to eq('This is preview about my life - 2')
+    expect(preview_image_clone.some_stuff).to eq("This is preview about my life - 2")
 
     # tags
     tags_clone = cloned.tags
     expect(tags_clone.map(&:value)).to match_array(%w[CI CD])
   end
 
-  it 'works with existing post' do
-    a_post = create(:post, title: 'Thing').tap do |p|
-      p.tags << create(:tag, value: 'RUM')
+  it "works with existing post" do
+    a_post = create(:post, title: "Thing").tap do |p|
+      p.tags << create(:tag, value: "RUM")
     end
 
     expect(AR::Topic.count).to eq(2)
@@ -122,7 +122,7 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
       post,
       traits: :copy,
       target: a_post,
-      preview_image: { suffix: ' - 3' }
+      preview_image: {suffix: " - 3"}
     ).to_record
     cloned.save!
 
@@ -135,21 +135,21 @@ describe 'AR adapter', :cleanup, adapter: :active_record, transactional: :active
     expect(AR::PreviewImage.count).to eq(2)
 
     # post
-    expect(a_post.title).to eq('Thing')
+    expect(a_post.title).to eq("Thing")
     expect(a_post.contents).to eq(post.contents)
 
     # preview_image
     preview_image_clone = a_post.image.preview_image
-    expect(preview_image_clone.some_stuff).to eq('This is preview about my life - 3')
+    expect(preview_image_clone.some_stuff).to eq("This is preview about my life - 3")
 
     # tags
     tags_clone = a_post.tags
     expect(tags_clone.map(&:value)).to match_array(%w[CI CD JVM RUM])
   end
 
-  it 'works with partial clone' do
+  it "works with partial clone" do
     cloned = AR::PostCloner.partial_apply(
-      { association: :tags },
+      {association: :tags},
       post,
       traits: :mark_as_clone,
       tags: %w[CI CD]

--- a/spec/clowne/integrations/adapter_lifecycle_spec.rb
+++ b/spec/clowne/integrations/adapter_lifecycle_spec.rb
@@ -1,4 +1,4 @@
-describe 'Adapter Lifecycle', :cleanup, adapter: :base, transactional: :active_record do
+describe "Adapter Lifecycle", :cleanup, adapter: :base, transactional: :active_record do
   class DummyAdapter < Clowne::Adapters::ActiveRecord
     class << self
       def dup_record(record)
@@ -25,9 +25,9 @@ describe 'Adapter Lifecycle', :cleanup, adapter: :base, transactional: :active_r
     end
   end
 
-  shared_examples 'pass adapter' do
+  shared_examples "pass adapter" do
     # rubocop:disable Layout/MultilineMethodCallIndentation
-    it 'clones topic' do
+    it "clones topic" do
       expect do
         operation.persist
       end.to change(AR::Topic, :count).by(+1)
@@ -35,7 +35,7 @@ describe 'Adapter Lifecycle', :cleanup, adapter: :base, transactional: :active_r
     end
     # rubocop:enable Layout/MultilineMethodCallIndentation
 
-    it 'uses DummyAdapter in all levels' do
+    it "uses DummyAdapter in all levels" do
       operation.persist
       clone = operation.to_record
       expect(clone.title).to eq("I'm a clone of AR::Topic-#{topic.id}")
@@ -46,8 +46,8 @@ describe 'Adapter Lifecycle', :cleanup, adapter: :base, transactional: :active_r
   let!(:topic) { create(:topic) }
   let!(:posts) { create_list(:post, 3, topic: topic) }
 
-  describe 'Pass root adapter over cloners' do
-    it_behaves_like 'pass adapter' do
+  describe "Pass root adapter over cloners" do
+    it_behaves_like "pass adapter" do
       subject(:operation) { AR::TopicCloner.call(topic) }
 
       before do
@@ -58,8 +58,8 @@ describe 'Adapter Lifecycle', :cleanup, adapter: :base, transactional: :active_r
     end
   end
 
-  describe 'Pass adapter over cloners as option' do
-    it_behaves_like 'pass adapter' do
+  describe "Pass adapter over cloners as option" do
+    it_behaves_like "pass adapter" do
       subject(:operation) { AR::TopicCloner.call(topic, adapter: DummyAdapter.new) }
     end
   end

--- a/spec/clowne/integrations/after_clone_spec.rb
+++ b/spec/clowne/integrations/after_clone_spec.rb
@@ -1,18 +1,18 @@
-describe 'Pre processing', :cleanup, adapter: :active_record, transactional: :active_record do
+describe "Pre processing", :cleanup, adapter: :active_record, transactional: :active_record do
   before(:all) do
     module AR
       class TopicCloner < Clowne::Cloner
         include_association :posts
 
         after_clone do |_origin, clone, **|
-          raise Clowne::UnprocessableSourceError, 'Topic has no posts!' if clone.posts.empty?
+          raise Clowne::UnprocessableSourceError, "Topic has no posts!" if clone.posts.empty?
         end
       end
     end
   end
 
   after(:all) do
-    AR.send(:remove_const, 'TopicCloner')
+    AR.send(:remove_const, "TopicCloner")
   end
 
   let!(:topic) { create(:topic) }
@@ -22,7 +22,7 @@ describe 'Pre processing', :cleanup, adapter: :active_record, transactional: :ac
       persisting it.' do
     subject(:operation) { AR::TopicCloner.call(topic) }
 
-    it 'raises error' do
+    it "raises error" do
       expect do
         operation.persist
       end.to raise_error(Clowne::UnprocessableSourceError)

--- a/spec/clowne/integrations/after_persist_spec.rb
+++ b/spec/clowne/integrations/after_persist_spec.rb
@@ -1,4 +1,4 @@
-describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :active_record do
+describe "Post Processing", :cleanup, adapter: :active_record, transactional: :active_record do
   before(:all) do
     module AR
       class TopicCloner < Clowne::Cloner
@@ -11,7 +11,7 @@ describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :a
       end
 
       class PostCloner < Clowne::Cloner
-        include_association :image, clone_with: 'AR::ImgCloner',
+        include_association :image, clone_with: "AR::ImgCloner",
                                     traits: %i[with_preview_image]
       end
 
@@ -21,7 +21,7 @@ describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :a
 
           after_persist do |origin, _clone, mapper:|
             cloned_preview_image = mapper.clone_of(origin.preview_image)
-            raise 'Leaf record does not have mapped source' if cloned_preview_image.nil?
+            raise "Leaf record does not have mapped source" if cloned_preview_image.nil?
           end
         end
       end
@@ -51,7 +51,7 @@ describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :a
     subject(:operation) { AR::TopicCloner.call(topic) }
 
     # rubocop:disable Layout/MultilineMethodCallIndentation
-    it 'clone and use cloned image' do
+    it "clone and use cloned image" do
       expect do
         operation.persist
       end.to change(AR::Topic, :count).by(+1)
@@ -66,7 +66,7 @@ describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :a
     # rubocop:enable Layout/MultilineMethodCallIndentation
   end
 
-  describe 'pass mappping' do
+  describe "pass mappping" do
     let(:another_image) { create(:image) }
     let(:mapper) do
       Class.new(Clowne::Utils::CloneMapper).new.tap do |stub_mapper|
@@ -76,7 +76,7 @@ describe 'Post Processing', :cleanup, adapter: :active_record, transactional: :a
 
     subject(:operation) { AR::TopicCloner.call(topic, mapper: mapper) }
 
-    it 'uses another_image' do
+    it "uses another_image" do
       cloned = operation.to_record
       cloned.save!
       expect { operation.run_after_persist }.to change {

--- a/spec/clowne/integrations/rspec_spec.rb
+++ b/spec/clowne/integrations/rspec_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'clowne/rspec'
+require "spec_helper"
+require "clowne/rspec"
 
-describe 'RSpec matchers and helpers', adapter: :active_record do
+describe "RSpec matchers and helpers", adapter: :active_record do
   before(:all) do
     module RSpecTest
       class ImageCloner < Clowne::Cloner
@@ -17,7 +17,7 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
       end
 
       class PostCloner < Clowne::Cloner
-        include_association :image, clone_with: 'RSpecTest::ImageCloner',
+        include_association :image, clone_with: "RSpecTest::ImageCloner",
                                     traits: %i[with_preview_image nullify_title],
                                     params: true
 
@@ -25,7 +25,7 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' Super!'
+            record.title = source.title + " Super!"
           end
         end
 
@@ -59,31 +59,31 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
     end
   end
 
-  describe '#clone_associations', type: :cloner do
+  describe "#clone_associations", type: :cloner do
     subject { RSpecTest::PostCloner }
 
-    it 'asserts when all associations specified' do
+    it "asserts when all associations specified" do
       expect(subject).to clone_associations(:image, :tags)
     end
 
-    it 'refutes when not all specified' do
+    it "refutes when not all specified" do
       expect do
         expect(subject).to clone_associations(:tags)
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
-    it 'raises ArgumentError when called not on cloner' do
+    it "raises ArgumentError when called not on cloner" do
       expect do
-        expect('foo').to clone_associations(:tags)
+        expect("foo").to clone_associations(:tags)
       end.to raise_error(ArgumentError)
     end
 
-    context 'with traits' do
-      it 'asserts when all associations specified' do
+    context "with traits" do
+      it "asserts when all associations specified" do
         expect(subject).to clone_associations(:image).with_traits(:without_tags)
       end
 
-      it 'refutes when not all specified' do
+      it "refutes when not all specified" do
         expect do
           expect(subject).to clone_associations(:tags, :image)
             .with_traits(:without_tags)
@@ -92,28 +92,28 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
     end
   end
 
-  describe '#clone_association', type: :cloner do
+  describe "#clone_association", type: :cloner do
     subject { RSpecTest::PostCloner }
 
-    it 'asserts when association is included' do
+    it "asserts when association is included" do
       expect(subject).to clone_association(:image)
     end
 
-    it 'refutes when association is not included (with traits)' do
+    it "refutes when association is not included (with traits)" do
       expect do
         expect(subject).to clone_association(:tags).with_traits(:without_tags)
       end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
     end
 
-    context 'clone_with' do
-      it 'asserts when cloner is correct' do
+    context "clone_with" do
+      it "asserts when cloner is correct" do
         expect(subject).to clone_association(
           :image,
           clone_with: RSpecTest::ImageCloner
         )
       end
 
-      it 'refutes when cloner is incorrect' do
+      it "refutes when cloner is incorrect" do
         expect do
           expect(subject).to clone_association(
             :image,
@@ -122,20 +122,20 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
         end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
-      it 'asserts with implicit cloner' do
+      it "asserts with implicit cloner" do
         expect(subject).to clone_association(:tags, clone_with: nil)
       end
     end
 
-    context 'traits' do
-      it 'asserts when all traits specified' do
+    context "traits" do
+      it "asserts when all traits specified" do
         expect(subject).to clone_association(
           :image,
           traits: [:with_preview_image, :nullify_title]
         )
       end
 
-      it 'refutes when not all traits specified' do
+      it "refutes when not all traits specified" do
         expect do
           expect(subject).to clone_association(
             :image,
@@ -145,15 +145,15 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
       end
     end
 
-    context 'scope' do
-      it 'asserts when scope is correct' do
+    context "scope" do
+      it "asserts when scope is correct" do
         expect(subject).to clone_association(
           :tags,
           scope: :popular
         ).with_traits(:with_popular_tags)
       end
 
-      it 'refutes when scope is incorrect' do
+      it "refutes when scope is incorrect" do
         expect do
           expect(subject).to clone_association(
             :tags,
@@ -162,7 +162,7 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
         end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
       end
 
-      it 'refutes when scope is dynamic' do
+      it "refutes when scope is dynamic" do
         expect do
           expect(subject).to clone_association(
             :tags,
@@ -172,17 +172,17 @@ describe 'RSpec matchers and helpers', adapter: :active_record do
       end
     end
 
-    context 'params' do
+    context "params" do
       subject { RSpecTest::ImageCloner }
 
-      it 'asserts when correct' do
+      it "asserts when correct" do
         expect(subject).to clone_association(
           :preview_image,
           params: :preview_image
         ).with_traits(:with_preview_image)
       end
 
-      it 'refutes when incorrect' do
+      it "refutes when incorrect" do
         expect do
           expect(subject).to clone_association(
             :preview_image,

--- a/spec/clowne/integrations/sequel_after_clone_spec.rb
+++ b/spec/clowne/integrations/sequel_after_clone_spec.rb
@@ -1,28 +1,28 @@
-describe 'Sequel Post Processing', :cleanup, adapter: :sequel, transactional: :sequel do
+describe "Sequel Post Processing", :cleanup, adapter: :sequel, transactional: :sequel do
   before(:all) do
     module Sequel
       class TopicCloner < Clowne::Cloner
         include_association :posts
 
         after_clone do |_origin, clone, **|
-          raise Clowne::UnprocessableSourceError, 'Topic has no posts!' if clone.posts.empty?
+          raise Clowne::UnprocessableSourceError, "Topic has no posts!" if clone.posts.empty?
         end
       end
     end
   end
 
   after(:all) do
-    Sequel.send(:remove_const, 'TopicCloner')
+    Sequel.send(:remove_const, "TopicCloner")
   end
 
-  let!(:topic) { create('sequel:topic') }
+  let!(:topic) { create("sequel:topic") }
 
   describe 'The main idea of "after clone" feature is a possibility
       to make some additional work or checks on cloned record before
       persisting it.' do
     subject(:operation) { Sequel::TopicCloner.call(topic) }
 
-    it 'raises error' do
+    it "raises error" do
       expect do
         operation.to_record
       end.to raise_error(Clowne::UnprocessableSourceError)

--- a/spec/clowne/integrations/sequel_after_persist_spec.rb
+++ b/spec/clowne/integrations/sequel_after_persist_spec.rb
@@ -1,4 +1,4 @@
-describe 'Sequel Post Processing', :cleanup, adapter: :sequel, transactional: :sequel do
+describe "Sequel Post Processing", :cleanup, adapter: :sequel, transactional: :sequel do
   before(:all) do
     module Sequel
       class TopicCloner < Clowne::Cloner
@@ -6,7 +6,7 @@ describe 'Sequel Post Processing', :cleanup, adapter: :sequel, transactional: :s
       end
 
       class PostCloner < Clowne::Cloner
-        include_association :image, clone_with: 'Sequel::ImgCloner'
+        include_association :image, clone_with: "Sequel::ImgCloner"
       end
 
       class ImgCloner < Clowne::Cloner
@@ -23,14 +23,14 @@ describe 'Sequel Post Processing', :cleanup, adapter: :sequel, transactional: :s
     end
   end
 
-  let!(:topic) { create('sequel:topic') }
-  let!(:post) { create('sequel:post', topic: topic) }
-  let!(:image) { create('sequel:image', post: post) }
+  let!(:topic) { create("sequel:topic") }
+  let!(:post) { create("sequel:post", topic: topic) }
+  let!(:image) { create("sequel:image", post: post) }
 
-  describe 'after_persist does not support for default mapper' do
+  describe "after_persist does not support for default mapper" do
     subject(:operation) { Sequel::TopicCloner.call(topic) }
 
-    it 'clone and use after_persis' do
+    it "clone and use after_persis" do
       expect { operation }.to raise_exception(
         Clowne::Adapters::Sequel::Specifications::AfterPersistDoesNotSupportException
       )

--- a/spec/clowne/integrations/sequel_spec.rb
+++ b/spec/clowne/integrations/sequel_spec.rb
@@ -1,8 +1,8 @@
-describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
+describe "Sequel adapter", :cleanup, adapter: :sequel, transactional: :sequel do
   before(:all) do
     module Sequel
       class UserCloner < Clowne::Cloner
-        finalize { |_, record| record.email = 'test@test.com' }
+        finalize { |_, record| record.email = "test@test.com" }
       end
 
       class ImgCloner < Clowne::Cloner
@@ -24,13 +24,13 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
       end
 
       class PostCloner < BasePostCloner
-        include_association :image, clone_with: 'Sequel::ImgCloner',
+        include_association :image, clone_with: "Sequel::ImgCloner",
                                     traits: %i[with_preview_image nullify_title]
         include_association :tags, ->(params) { where(value: params[:tags]) if params[:tags] }
 
         trait :mark_as_clone do
           finalize do |source, record|
-            record.title = source.title + ' Super!'
+            record.title = source.title + " Super!"
           end
         end
 
@@ -44,7 +44,7 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
 
       class PreviewImageCloner < Clowne::Cloner
         finalize do |_source, record|
-          record.some_stuff = record.some_stuff + ' - 2'
+          record.some_stuff = record.some_stuff + " - 2"
         end
       end
     end
@@ -56,21 +56,21 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
     end
   end
 
-  let!(:post) { create('sequel:post', title: 'TeamCity') }
-  let!(:image) { create('sequel:image', title: 'Manager', post: post) }
-  let!(:user) { create('sequel:user', email: 'user@email.com') }
+  let!(:post) { create("sequel:post", title: "TeamCity") }
+  let!(:image) { create("sequel:image", title: "Manager", post: post) }
+  let!(:user) { create("sequel:user", email: "user@email.com") }
   let!(:preview_image) do
-    create('sequel:preview_image', some_stuff: 'This is preview_image about my life', image: image)
+    create("sequel:preview_image", some_stuff: "This is preview_image about my life", image: image)
   end
   let(:topic) { post.topic }
 
   let!(:tags) do
-    %w[CI CD JVM].map { |value| create('sequel:tag', value: value) }.tap do |items|
+    %w[CI CD JVM].map { |value| create("sequel:tag", value: value) }.tap do |items|
       items.each { |tag| post.add_tag(tag) }
     end
   end
 
-  it 'clone all stuff' do
+  it "clone all stuff" do
     expect(Sequel::Topic.count).to eq(1)
     expect(Sequel::Post.count).to eq(1)
     expect(Sequel::Tag.count).to eq(3)
@@ -81,7 +81,7 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
       post,
       traits: :mark_as_clone,
       tags: %w[CI CD],
-      post_contents: 'THIS IS CLONE! (☉_☉)'
+      post_contents: "THIS IS CLONE! (☉_☉)"
     )
     cloned = cloned_wrapper.persist
 
@@ -93,8 +93,8 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
 
     # post
     expect(cloned).to be_a(Sequel::Post)
-    expect(cloned.title).to eq('TeamCity Super!')
-    expect(cloned.contents).to eq('THIS IS CLONE! (☉_☉)')
+    expect(cloned.title).to eq("TeamCity Super!")
+    expect(cloned.contents).to eq("THIS IS CLONE! (☉_☉)")
 
     # image
     image_clone = cloned.image
@@ -104,16 +104,16 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
 
     # preview_image
     preview_image_clone = image_clone.preview_image
-    expect(preview_image_clone.some_stuff).to eq('This is preview_image about my life - 2')
+    expect(preview_image_clone.some_stuff).to eq("This is preview_image about my life - 2")
 
     # tags
     tags_clone = cloned.tags
     expect(tags_clone.map(&:value)).to match_array(%w[CI CD])
   end
 
-  it 'works with existing post', :aggregate_failures do
-    a_post = create('sequel:post', title: 'Thing').tap do |p|
-      p.add_tag create('sequel:tag', value: 'ROM')
+  it "works with existing post", :aggregate_failures do
+    a_post = create("sequel:post", title: "Thing").tap do |p|
+      p.add_tag create("sequel:tag", value: "ROM")
     end
 
     expect(Sequel::Topic.count).to eq(2)
@@ -140,19 +140,19 @@ describe 'Sequel adapter', :cleanup, adapter: :sequel, transactional: :sequel do
 
     # post
     expect(a_post).to be_a(Sequel::Post)
-    expect(a_post.title).to eq('Thing')
+    expect(a_post.title).to eq("Thing")
     expect(a_post.contents).to eq(post.contents)
 
     # preview_image
     preview_image_clone = a_post.image.preview_image
-    expect(preview_image_clone.some_stuff).to eq('This is preview_image about my life - 2')
+    expect(preview_image_clone.some_stuff).to eq("This is preview_image about my life - 2")
 
     # tags
     tags_clone = a_post.tags
     expect(tags_clone.map(&:value)).to match_array(%w[CI CD JVM ROM])
   end
 
-  it 'works with no association model' do
+  it "works with no association model" do
     expect(Sequel::User.count).to eq(2)
     Sequel::UserCloner.call(user).persist
     expect(Sequel::User.count).to eq(3)

--- a/spec/clowne/planner_spec.rb
+++ b/spec/clowne/planner_spec.rb
@@ -1,12 +1,12 @@
 describe Clowne::Planner, adapter: :active_record do
   let(:adapter) { Clowne::Adapters::ActiveRecord }
 
-  describe '.compile' do
+  describe ".compile" do
     let(:options) { {} }
 
     subject { described_class.compile(adapter, cloner, **options).declarations }
 
-    context 'when cloner with one included association' do
+    context "when cloner with one included association" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           include_association :users
@@ -15,12 +15,12 @@ describe Clowne::Planner, adapter: :active_record do
 
       specify do
         is_expected.to match_declarations(
-          [[:association, Clowne::Declarations::IncludeAssociation, { name: :users }]]
+          [[:association, Clowne::Declarations::IncludeAssociation, {name: :users}]]
         )
       end
     end
 
-    context 'when cloner with nullify declarations' do
+    context "when cloner with nullify declarations" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           nullify :foo, :bar
@@ -31,13 +31,13 @@ describe Clowne::Planner, adapter: :active_record do
       specify do
         is_expected.to match_declarations(
           [
-            [:nullify, Clowne::Declarations::Nullify, { attributes: %i[foo bar] }],
-            [:nullify, Clowne::Declarations::Nullify, { attributes: %i[baz] }]
+            [:nullify, Clowne::Declarations::Nullify, {attributes: %i[foo bar]}],
+            [:nullify, Clowne::Declarations::Nullify, {attributes: %i[baz]}],
           ]
         )
       end
 
-      context 'when cloner with main nullify declaration and with trait' do
+      context "when cloner with main nullify declaration and with trait" do
         let(:cloner) do
           Class.new(Clowne::Cloner) do
             nullify :foo
@@ -48,20 +48,20 @@ describe Clowne::Planner, adapter: :active_record do
           end
         end
 
-        let(:options) { { traits: [:with_nullify] } }
+        let(:options) { {traits: [:with_nullify]} }
 
         specify do
           is_expected.to match_declarations(
             [
-              [:nullify, Clowne::Declarations::Nullify, { attributes: %i[foo] }],
-              [:nullify, Clowne::Declarations::Nullify, { attributes: %i[bar] }]
+              [:nullify, Clowne::Declarations::Nullify, {attributes: %i[foo]}],
+              [:nullify, Clowne::Declarations::Nullify, {attributes: %i[bar]}],
             ]
           )
         end
       end
     end
 
-    context 'when cloner with finalize declaration' do
+    context "when cloner with finalize declaration" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           finalize(&proc { 1 + 1 })
@@ -72,14 +72,14 @@ describe Clowne::Planner, adapter: :active_record do
       specify do
         is_expected.to match_declarations(
           [
-            [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-            [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 2 } }]
+            [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+            [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 2 }}],
           ]
         )
       end
     end
 
-    context 'when multiple traits' do
+    context "when multiple traits" do
       let(:cloner) do
         Class.new(Clowne::Cloner) do
           include_associations :users, :posts
@@ -99,50 +99,50 @@ describe Clowne::Planner, adapter: :active_record do
         end
       end
 
-      context 'when planing without traits' do
+      context "when planing without traits" do
         specify do
           is_expected.to match_declarations(
             [
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :users }],
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :posts }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }]
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :users}],
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :posts}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
             ]
           )
         end
       end
 
-      context 'when one trait is active' do
-        let(:options) { { traits: [:with_brands] } }
+      context "when one trait is active" do
+        let(:options) { {traits: [:with_brands]} }
 
         specify do
           is_expected.to match_declarations(
             [
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :users }],
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :brands }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 2 } }]
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :users}],
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :brands}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 2 }}],
             ]
           )
         end
       end
 
-      context 'when all traits are active' do
-        let(:options) { { traits: [:with_brands, :clear_fields] } }
+      context "when all traits are active" do
+        let(:options) { {traits: [:with_brands, :clear_fields]} }
 
         specify do
           is_expected.to match_declarations(
             [
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :users }],
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :brands }],
-              [:nullify, Clowne::Declarations::Nullify, { attributes: %i[extra data meta] }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 2 } }]
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :users}],
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :brands}],
+              [:nullify, Clowne::Declarations::Nullify, {attributes: %i[extra data meta]}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 2 }}],
             ]
           )
         end
       end
 
-      context 'when inherited cloner' do
+      context "when inherited cloner" do
         let(:new_cloner) do
           Class.new(cloner) do
             include_association :files
@@ -155,18 +155,18 @@ describe Clowne::Planner, adapter: :active_record do
 
         subject { described_class.compile(adapter, new_cloner, **options).declarations }
 
-        let(:options) { { traits: [:with_brands, :clear_fields] } }
+        let(:options) { {traits: [:with_brands, :clear_fields]} }
 
         specify do
           is_expected.to match_declarations(
             [
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :users }],
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :files }],
-              [:association, Clowne::Declarations::IncludeAssociation, { name: :brands }],
-              [:nullify, Clowne::Declarations::Nullify, { attributes: %i[extra data meta] }],
-              [:nullify, Clowne::Declarations::Nullify, { attributes: %i[files_cache] }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 1 } }],
-              [:finalize, Clowne::Declarations::Finalize, { block: proc { 1 + 2 } }]
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :users}],
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :files}],
+              [:association, Clowne::Declarations::IncludeAssociation, {name: :brands}],
+              [:nullify, Clowne::Declarations::Nullify, {attributes: %i[extra data meta]}],
+              [:nullify, Clowne::Declarations::Nullify, {attributes: %i[files_cache]}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 1 }}],
+              [:finalize, Clowne::Declarations::Finalize, {block: proc { 1 + 2 }}],
             ]
           )
         end

--- a/spec/clowne/resolvers/after_clone_spec.rb
+++ b/spec/clowne/resolvers/after_clone_spec.rb
@@ -1,12 +1,12 @@
 describe Clowne::Resolvers::AfterClone do
   let(:declaration) { Clowne::Declarations::AfterClone.new(&block) }
 
-  describe '.call' do
-    let(:source) { AR::User.create(email: 'admin@example.com') }
+  describe ".call" do
+    let(:source) { AR::User.create(email: "admin@example.com") }
     let(:params) { {} }
     let(:block) do
       proc do |_source, record|
-        record.email = 'admin-cloned@example.com'
+        record.email = "admin-cloned@example.com"
       end
     end
 
@@ -19,22 +19,22 @@ describe Clowne::Resolvers::AfterClone do
       operation.to_record
     end
 
-    it 'execute after_clone block' do
+    it "execute after_clone block" do
       expect(result).to be_a(AR::User)
-      expect(result.email).to eq('admin-cloned@example.com')
+      expect(result.email).to eq("admin-cloned@example.com")
     end
 
-    context 'with params' do
-      let(:params) { { email: 'admin@yahoo.com' } }
+    context "with params" do
+      let(:params) { {email: "admin@yahoo.com"} }
       let(:block) do
         proc do |_source, record, params|
           record.email = params[:email]
         end
       end
 
-      it 'execute after_clone block with params' do
+      it "execute after_clone block with params" do
         expect(result).to be_a(AR::User)
-        expect(result.email).to eq('admin@yahoo.com')
+        expect(result.email).to eq("admin@yahoo.com")
       end
     end
   end

--- a/spec/clowne/resolvers/after_persist_spec.rb
+++ b/spec/clowne/resolvers/after_persist_spec.rb
@@ -1,8 +1,8 @@
 describe Clowne::Resolvers::AfterPersist do
   let(:declaration) { Clowne::Declarations::AfterPersist.new(&block) }
 
-  describe '.call' do
-    let(:source) { AR::User.create(email: 'admin@example.com') }
+  describe ".call" do
+    let(:source) { AR::User.create(email: "admin@example.com") }
     let(:params) { {} }
     let(:block) do
       proc do |source, record, mapper:|
@@ -15,27 +15,27 @@ describe Clowne::Resolvers::AfterPersist do
       operation = Clowne::Utils::Operation.wrap do
         described_class.call(source, record, declaration, params: params)
       end
-      operation.add_mapping(source, 'example.com')
+      operation.add_mapping(source, "example.com")
       operation.persist
       operation.to_record
     end
 
-    it 'execute after_persist block' do
+    it "execute after_persist block" do
       expect(result).to be_a(AR::User)
       expect(result.email).to eq("admin#{result.id}@example.com")
     end
 
-    context 'with params' do
-      let(:params) { { email: 'admin@yahoo.com' } }
+    context "with params" do
+      let(:params) { {email: "admin@yahoo.com"} }
       let(:block) do
         proc do |_source, record, params|
           record.email = params[:email]
         end
       end
 
-      it 'execute finalize block with params' do
+      it "execute finalize block with params" do
         expect(result).to be_a(AR::User)
-        expect(result.email).to eq('admin@yahoo.com')
+        expect(result.email).to eq("admin@yahoo.com")
       end
     end
   end

--- a/spec/clowne/resolvers/finalize_spec.rb
+++ b/spec/clowne/resolvers/finalize_spec.rb
@@ -1,12 +1,12 @@
 describe Clowne::Resolvers::Finalize do
   let(:declaration) { Clowne::Declarations::Finalize.new(&block) }
 
-  describe '.call' do
-    let(:source) { AR::User.new(email: 'admin@example.com') }
+  describe ".call" do
+    let(:source) { AR::User.new(email: "admin@example.com") }
     let(:params) { {} }
     let(:block) do
       proc do |source, record|
-        record.email = source.email.gsub('example.com', 'gmail.com')
+        record.email = source.email.gsub("example.com", "gmail.com")
       end
     end
 
@@ -15,22 +15,22 @@ describe Clowne::Resolvers::Finalize do
       described_class.call(source, record, declaration, params: params)
     end
 
-    it 'execute finalize block' do
+    it "execute finalize block" do
       expect(result).to be_a(AR::User)
-      expect(result.email).to eq('admin@gmail.com')
+      expect(result.email).to eq("admin@gmail.com")
     end
 
-    context 'with params' do
-      let(:params) { { email: 'admin@yahoo.com' } }
+    context "with params" do
+      let(:params) { {email: "admin@yahoo.com"} }
       let(:block) do
         proc do |_source, record, params|
           record.email = params[:email]
         end
       end
 
-      it 'execute finalize block with params' do
+      it "execute finalize block with params" do
         expect(result).to be_a(AR::User)
-        expect(result.email).to eq('admin@yahoo.com')
+        expect(result.email).to eq("admin@yahoo.com")
       end
     end
   end

--- a/spec/clowne/resolvers/nullify_spec.rb
+++ b/spec/clowne/resolvers/nullify_spec.rb
@@ -1,21 +1,21 @@
 describe Clowne::Resolvers::Nullify do
   let(:declaration) { Clowne::Declarations::Nullify.new(*args) }
 
-  describe '.call' do
-    let(:record) { AR::User.new(name: 'Admin', email: 'admin@example.com') }
+  describe ".call" do
+    let(:record) { AR::User.new(name: "Admin", email: "admin@example.com") }
     let(:args) { [:email] }
 
-    it 'nullifies fields' do
+    it "nullifies fields" do
       result = described_class.call(double, record, declaration)
       expect(result).to be_a(AR::User)
-      expect(result.name).to eq('Admin')
+      expect(result.name).to eq("Admin")
       expect(result.email).to be_nil
     end
 
-    context 'with multiple attributes' do
+    context "with multiple attributes" do
       let(:args) { [:name, :email] }
 
-      it 'nullifies fields' do
+      it "nullifies fields" do
         result = described_class.call(double, record, declaration)
         expect(result).to be_a(AR::User)
         expect(result.name).to be_nil

--- a/spec/clowne/utils/clone_mapper_spec.rb
+++ b/spec/clowne/utils/clone_mapper_spec.rb
@@ -7,7 +7,7 @@ describe Clowne::Utils::CloneMapper do
   let(:clone) { AR::Post.new }
   let(:clone2) { AR::Post.new }
 
-  specify 'mapper flow' do
+  specify "mapper flow" do
     mapper.add(origin, clone)
     mapper.add(origin2, clone2)
 

--- a/spec/clowne/utils/params_spec.rb
+++ b/spec/clowne/utils/params_spec.rb
@@ -1,95 +1,95 @@
 describe Clowne::Utils::Params do
-  describe 'build proxy' do
+  describe "build proxy" do
     let(:params) do
       {
-        profile: { data: { name: 'Robin' } },
-        rating: 10
+        profile: {data: {name: "Robin"}},
+        rating: 10,
       }
     end
     let(:permitted_params) { subject.permit(params: params) }
 
     subject { described_class.proxy(value) }
 
-    context 'when value is true' do
+    context "when value is true" do
       let(:value) { true }
 
       it { is_expected.to be_a(Clowne::Utils::Params::PassProxy) }
 
-      it 'return all params' do
+      it "return all params" do
         expect(permitted_params).to eq(params)
       end
     end
 
-    context 'when value is false' do
+    context "when value is false" do
       let(:value) { false }
 
       it { is_expected.to be_a(Clowne::Utils::Params::NullProxy) }
 
-      it 'return empty hash' do
+      it "return empty hash" do
         expect(permitted_params).to eq({})
       end
     end
 
-    context 'when value is false' do
+    context "when value is false" do
       let(:value) { nil }
 
       it { is_expected.to be_a(Clowne::Utils::Params::NullProxy) }
 
-      it 'return empty hash' do
+      it "return empty hash" do
         expect(permitted_params).to eq({})
       end
     end
 
-    context 'when value is a block' do
+    context "when value is a block" do
       let(:parent) { double }
       let(:permitted_params) { subject.permit(params: params, parent: parent) }
 
-      context 'with 1 args' do
+      context "with 1 args" do
         let(:value) { ->(p) { p[:profile][:data] } }
 
         it { is_expected.to be_a(Clowne::Utils::Params::BlockProxy) }
 
-        it 'return nested hash' do
-          expect(permitted_params).to eq(name: 'Robin')
+        it "return nested hash" do
+          expect(permitted_params).to eq(name: "Robin")
         end
       end
 
-      context 'with 2 args' do
+      context "with 2 args" do
         let(:value) { ->(p, parent) { p[:profile][:data].merge(parent: parent) } }
 
         it { is_expected.to be_a(Clowne::Utils::Params::BlockProxy) }
 
-        it 'return nested hash with record' do
-          expect(permitted_params).to eq(name: 'Robin', parent: parent)
+        it "return nested hash with record" do
+          expect(permitted_params).to eq(name: "Robin", parent: parent)
         end
       end
     end
 
-    context 'when value is a key' do
+    context "when value is a key" do
       let(:value) { :profile }
 
       it { is_expected.to be_a(Clowne::Utils::Params::KeyProxy) }
 
-      it 'return nested hash' do
-        expect(permitted_params).to eq(data: { name: 'Robin' })
+      it "return nested hash" do
+        expect(permitted_params).to eq(data: {name: "Robin"})
       end
     end
 
-    context 'when value is a key but nested values is not a Hash' do
+    context "when value is a key but nested values is not a Hash" do
       let(:value) { :rating }
 
       it { is_expected.to be_a(Clowne::Utils::Params::KeyProxy) }
 
-      it 'raise KeyError' do
+      it "raise KeyError" do
         expect { permitted_params }.to raise_error(KeyError, "value by key 'rating' must be a Hash")
       end
     end
 
-    context 'when value is undefined' do
+    context "when value is undefined" do
       let(:value) { :blah }
 
-      it 'raise KeyError' do
-        expect { permitted_params }.to raise_error(KeyError, 'key not found: :blah')
+      it "raise KeyError" do
+        expect { permitted_params }.to raise_error(KeyError, "key not found: :blah")
       end
     end
   end

--- a/spec/clowne/utils/plan_spec.rb
+++ b/spec/clowne/utils/plan_spec.rb
@@ -1,5 +1,5 @@
 describe Clowne::Utils::Plan do
-  describe '#declarations' do
+  describe "#declarations" do
     let(:registry) do
       Clowne::Adapters::Registry.new.tap do |r|
         r.append :a
@@ -10,20 +10,20 @@ describe Clowne::Utils::Plan do
 
     subject { described_class.new(registry) }
 
-    it 'works' do
-      subject.add :b, 'item_1'
-      subject.set :c, 'scalar_1'
-      subject.add_to :a, :key_1, 'value_1'
-      subject.add_to :a, :key_2, 'value_2'
-      subject.add :b, 'item_2'
+    it "works" do
+      subject.add :b, "item_1"
+      subject.set :c, "scalar_1"
+      subject.add_to :a, :key_1, "value_1"
+      subject.add_to :a, :key_2, "value_2"
+      subject.add :b, "item_2"
 
       expect(subject.declarations).to eq(
         [
-          [:a, 'value_1'],
-          [:a, 'value_2'],
-          [:b, 'item_1'],
-          [:b, 'item_2'],
-          [:c, 'scalar_1']
+          [:a, "value_1"],
+          [:a, "value_2"],
+          [:b, "item_1"],
+          [:b, "item_2"],
+          [:c, "scalar_1"],
         ]
       )
 
@@ -33,29 +33,29 @@ describe Clowne::Utils::Plan do
       # return the same cached version
       expect(subject.declarations).to eq(
         [
-          [:a, 'value_1'],
-          [:a, 'value_2'],
-          [:b, 'item_1'],
-          [:b, 'item_2'],
-          [:c, 'scalar_1']
+          [:a, "value_1"],
+          [:a, "value_2"],
+          [:b, "item_1"],
+          [:b, "item_2"],
+          [:c, "scalar_1"],
         ]
       )
 
       expect(subject.declarations(true)).to eq(
         [
-          [:a, 'value_2'],
-          [:b, 'item_1'],
-          [:b, 'item_2']
+          [:a, "value_2"],
+          [:b, "item_1"],
+          [:b, "item_2"],
         ]
       )
 
-      subject.add_to(:a, :key_1, 'new_item')
+      subject.add_to(:a, :key_1, "new_item")
 
       expect(subject.declarations(true)).to eq(
         [
-          [:a, 'value_2'],
-          [:b, 'item_1'],
-          [:b, 'item_2']
+          [:a, "value_2"],
+          [:b, "item_1"],
+          [:b, "item_2"],
         ]
       )
     end

--- a/spec/clowne_spec.rb
+++ b/spec/clowne_spec.rb
@@ -1,5 +1,5 @@
 describe Clowne do
-  it 'has a version number' do
+  it "has a version number" do
     expect(Clowne::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,17 @@
-if ENV['CC_REPORT']
-  require 'simplecov'
+if ENV["CC_REPORT"]
+  require "simplecov"
   SimpleCov.start do
-    add_filter '/spec/'
+    add_filter "/spec/"
   end
 end
 
-require 'active_record'
-require 'sequel'
-require 'clowne'
-require 'factory_bot'
+require "active_record"
+require "sequel"
+require "clowne"
+require "factory_bot"
 
 begin
-  require 'pry-byebug'
+  require "pry-byebug"
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
@@ -24,7 +24,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 Clowne.default_adapter = :base
 
 RSpec.configure do |config|
-  config.example_status_persistence_file_path = '.rspec_status'
+  config.example_status_persistence_file_path = ".rspec_status"
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 
@@ -35,8 +35,8 @@ RSpec.configure do |config|
   end
 
   config.include FactoryBot::Syntax::Methods
-  config.include_context 'adapter:active_record', adapter: :active_record
-  config.include_context 'adapter:sequel', adapter: :sequel
+  config.include_context "adapter:active_record", adapter: :active_record
+  config.include_context "adapter:sequel", adapter: :sequel
 
   config.before(:each) do
     Clowne::Utils::Operation.clear!

--- a/spec/support/active_record/factories.rb
+++ b/spec/support/active_record/factories.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user, class: 'AR::User' do
+  factory :user, class: "AR::User" do
     sequence(:name) { |n| "John #{n}" }
     sequence(:email) { |n| "clowne_#{n}@test.rb" }
 
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
   end
 
-  factory :post, class: 'AR::Post' do
+  factory :post, class: "AR::Post" do
     sequence(:title) { |n| "Post ##{n}" }
     sequence(:contents) { |n| "About a number #{n}" }
 
@@ -33,7 +33,7 @@ FactoryBot.define do
     end
   end
 
-  factory :image, class: 'AR::Image' do
+  factory :image, class: "AR::Image" do
     sequence(:title) { |n| "Image ##{n}" }
 
     trait :with_preview_image do
@@ -41,13 +41,13 @@ FactoryBot.define do
     end
   end
 
-  factory :preview_image, class: 'AR::PreviewImage' do
+  factory :preview_image, class: "AR::PreviewImage" do
     sequence(:some_stuff) { |n| "Bla-bla #{n}" }
 
     image
   end
 
-  factory :topic, class: 'AR::Topic' do
+  factory :topic, class: "AR::Topic" do
     sequence(:title) { |n| "Topic ##{n}}" }
     sequence(:description) { |n| "Let's talk about #{n}" }
 
@@ -62,7 +62,7 @@ FactoryBot.define do
     end
   end
 
-  factory :tag, class: 'AR::Tag' do
+  factory :tag, class: "AR::Tag" do
     sequence(:value) { |n| "T#{n}" }
 
     transient do

--- a/spec/support/active_record/initializer.rb
+++ b/spec/support/active_record/initializer.rb
@@ -1,7 +1,7 @@
-require 'activerecord-jdbc-adapter' if defined? JRUBY_VERSION
-require 'activerecord-jdbcsqlite3-adapter' if defined? JRUBY_VERSION
+require "activerecord-jdbc-adapter" if defined? JRUBY_VERSION
+require "activerecord-jdbcsqlite3-adapter" if defined? JRUBY_VERSION
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 
-require_relative './schema.rb'
-require_relative './models.rb'
+require_relative "./schema.rb"
+require_relative "./models.rb"

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -1,37 +1,37 @@
 module AR
   class Topic < ActiveRecord::Base
-    has_many :posts, class_name: 'AR::Post'
-    belongs_to :image, class_name: 'AR::Image'
+    has_many :posts, class_name: "AR::Post"
+    belongs_to :image, class_name: "AR::Image"
   end
 
   class User < ActiveRecord::Base
-    has_many :posts, class_name: 'AR::Post', foreign_key: :owner_id
-    has_many :images, class_name: 'AR::Image', through: :posts
+    has_many :posts, class_name: "AR::Post", foreign_key: :owner_id
+    has_many :images, class_name: "AR::Image", through: :posts
   end
 
   class Post < ActiveRecord::Base
-    belongs_to :topic, class_name: 'AR::Topic'
-    belongs_to :owner, class_name: 'AR::User'
+    belongs_to :topic, class_name: "AR::Topic"
+    belongs_to :owner, class_name: "AR::User"
 
-    has_one :image, class_name: 'AR::Image'
-    has_one :preview_image, through: :image, class_name: 'AR::PreviewImage'
+    has_one :image, class_name: "AR::Image"
+    has_one :preview_image, through: :image, class_name: "AR::PreviewImage"
 
-    has_and_belongs_to_many :tags, class_name: 'AR::Tag'
+    has_and_belongs_to_many :tags, class_name: "AR::Tag"
 
     scope :alpha_first, -> { order(title: :asc).limit(1) }
   end
 
   class Image < ActiveRecord::Base
-    belongs_to :post, class_name: 'AR::Post'
+    belongs_to :post, class_name: "AR::Post"
 
-    has_one :preview_image, class_name: 'AR::PreviewImage'
+    has_one :preview_image, class_name: "AR::PreviewImage"
   end
 
   class PreviewImage < ActiveRecord::Base
-    belongs_to :image, class_name: 'AR::Image'
+    belongs_to :image, class_name: "AR::Image"
   end
 
   class Tag < ActiveRecord::Base
-    has_and_belongs_to_many :posts, class_name: 'AR::Post'
+    has_and_belongs_to_many :posts, class_name: "AR::Post"
   end
 end

--- a/spec/support/matchers/be_a_declaration.rb
+++ b/spec/support/matchers/be_a_declaration.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations'
+require "rspec/expectations"
 
 RSpec::Matchers.define :match_declarations do |expected_declarations|
   match do |actual|

--- a/spec/support/sequel/factories.rb
+++ b/spec/support/sequel/factories.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   to_create(&:save)
 
-  factory 'sequel:topic', class: 'Sequel::Topic' do
+  factory "sequel:topic", class: "Sequel::Topic" do
     sequence(:title) { |n| "Topic ##{n}}" }
     sequence(:description) { |n| "Let's talk about #{n}" }
 
@@ -11,12 +11,12 @@ FactoryBot.define do
 
     trait :with_posts do
       after(:create) do |topic, ev|
-        create_list('sequel:post', ev.posts_num, topic: topic)
+        create_list("sequel:post", ev.posts_num, topic: topic)
       end
     end
   end
 
-  factory 'sequel:user', class: 'Sequel::User' do
+  factory "sequel:user", class: "Sequel::User" do
     sequence(:name) { |n| "John #{n}" }
     sequence(:email) { |n| "clowne_#{n}@test.rb" }
 
@@ -26,17 +26,17 @@ FactoryBot.define do
 
     trait :with_posts do
       after(:create) do |user, ev|
-        create_list('sequel:post', ev.posts_num, owner: user)
+        create_list("sequel:post", ev.posts_num, owner: user)
       end
     end
   end
 
-  factory 'sequel:post', class: 'Sequel::Post' do
+  factory "sequel:post", class: "Sequel::Post" do
     sequence(:title) { |n| "Post ##{n}" }
     sequence(:contents) { |n| "About a number #{n}" }
 
-    association :owner, factory: 'sequel:user'
-    association :topic, factory: 'sequel:topic'
+    association :owner, factory: "sequel:user"
+    association :topic, factory: "sequel:topic"
 
     transient do
       tags_num { 2 }
@@ -44,28 +44,28 @@ FactoryBot.define do
 
     trait :with_tags do
       after(:create) do |post, ev|
-        create_list('sequel:tag', ev.tags_num).each do |tag|
+        create_list("sequel:tag", ev.tags_num).each do |tag|
           tag.add_post(post)
         end
       end
     end
   end
 
-  factory 'sequel:image', class: 'Sequel::Image' do
+  factory "sequel:image", class: "Sequel::Image" do
     sequence(:title) { |n| "Image  ##{n}" }
 
     trait :with_preview_image do
-      after(:create) { |image| create('sequel:preview_image', image: image) }
+      after(:create) { |image| create("sequel:preview_image", image: image) }
     end
   end
 
-  factory 'sequel:preview_image', class: 'Sequel::PreviewImage' do
+  factory "sequel:preview_image", class: "Sequel::PreviewImage" do
     sequence(:some_stuff) { |n| "Bla-bla #{n}" }
 
-    association :image, factory: 'sequel:image'
+    association :image, factory: "sequel:image"
   end
 
-  factory 'sequel:tag', class: 'Sequel::Tag' do
+  factory "sequel:tag", class: "Sequel::Tag" do
     sequence(:value) { |n| "T#{n}" }
 
     transient do
@@ -74,7 +74,7 @@ FactoryBot.define do
 
     trait :with_posts do
       after(:create) do |tag, ev|
-        create_list('sequel:post', ev.posts_num).each do |post|
+        create_list("sequel:post", ev.posts_num).each do |post|
           post.add_tag(tag)
         end
       end

--- a/spec/support/sequel/initializer.rb
+++ b/spec/support/sequel/initializer.rb
@@ -1,12 +1,12 @@
-require 'sequel'
+require "sequel"
 db =
-  if RUBY_PLATFORM =~ /java/
-    'jdbc:sqlite::memory:'
+  if RUBY_PLATFORM.match?(/java/)
+    "jdbc:sqlite::memory:"
   else
-    'sqlite::memory:'
+    "sqlite::memory:"
   end
 
 SEQUEL_DB = Sequel.connect(db)
 
-require_relative './schema.rb'
-require_relative './models.rb'
+require_relative "./schema.rb"
+require_relative "./models.rb"

--- a/spec/support/shared_contexts/transactional.rb
+++ b/spec/support/shared_contexts/transactional.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_context 'transactional:active_record', transactional: :active_record do
+shared_context "transactional:active_record", transactional: :active_record do
   prepend_before(:each) do
     ActiveRecord::Base.connection.begin_transaction(joinable: false)
   end
@@ -10,7 +10,7 @@ shared_context 'transactional:active_record', transactional: :active_record do
   end
 end
 
-shared_context 'transactional:sequel', transactional: :sequel do
+shared_context "transactional:sequel", transactional: :sequel do
   prepend_before(:each) do
     @conn = SEQUEL_DB.pool.send :acquire, Thread.current
     SEQUEL_DB.send(:add_transaction, @conn, {})


### PR DESCRIPTION
Closes #36 

All offenses were fixed with `rubocop --auto-correct`