### PR TITLE
Feat: Access mapper in after_clone

### DIFF
--- a/lib/clowne/resolvers/after_clone.rb
+++ b/lib/clowne/resolvers/after_clone.rb
@@ -5,9 +5,10 @@ module Clowne
     module AfterClone # :nodoc: all
       def self.call(source, record, declaration, params:, **_options)
         operation = Clowne::Utils::Operation.current
+        params ||= {}
         operation.add_after_clone(
           proc do
-            declaration.block.call(source, record, params)
+            declaration.block.call(source, record, params.merge(mapper: operation.mapper))
           end
         )
         record


### PR DESCRIPTION
# Summary
From this [docs](https://clowne.evilmartians.io/docs/after_persist.html), I see that we can use `after_commit` to fix broken associations. But there is another use case that needs to fix the associations before `save`, and it's better to in `after_clone` phrase.

## Example
```
class Organisation < ActiveRecord::Base
  # create_table :organisations do |t|
  # end

  has_many :leave_requests
  has_many :leave_categories
end

class LeaveCategory < ActiveRecord::Base
  # create_table :leave_categories do |t|
  #   t.integer :organisation_id
  # end

  has_many :leave_requests
end

class LeaveRequest < ActiveRecord::Base
  # create_table :leave_requests do |t|
  #   t.integer :organisation_id
  #   t.integer :leave_category_id
  # end

  belongs_to :organisation
  belongs_to :leave_category
end
```

When cloning org, to map `leave requests` to cloned `leave categories`, we need to do it in `after_clone` step by using `mapper`.