### PR TITLE
Fix Ruby 2.7 deprecation notice for Proc.new passed block capture

### DIFF
--- a/lib/clowne/declarations.rb
+++ b/lib/clowne/declarations.rb
@@ -7,12 +7,12 @@ module Clowne
   module Declarations # :nodoc:
     module_function
 
-    def add(id, declaration = nil)
-      declaration = Proc.new if block_given?
+    def add(id, declaration = nil, &block)
+      declaration = block if block_given?
 
       if declaration.is_a?(Class)
-        DSL.send(:define_method, id) do |*args, &block|
-          declarations.push declaration.new(*args, &block)
+        DSL.send(:define_method, id) do |*args, &inner_block|
+          declarations.push declaration.new(*args, &inner_block)
         end
       elsif declaration.is_a?(Proc)
         DSL.send(:define_method, id, &declaration)


### PR DESCRIPTION
New Ruby 2.7 projects running this gem get the following deprecation warning.

Looks like an easy fix, so I hopped in and made the change. 

Open to comments and criticism :)

```
lib/clowne/declarations.rb:11: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/bundle/ruby/2.7.0/gems/clowne-1.1.0/lib/clowne/declarations.rb:11: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/bundle/ruby/2.7.0/gems/clowne-1.1.0/lib/clowne/declarations.rb:11: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

for the following lines: 
```
module Clowne
  module Declarations # :nodoc:
    module_function

    def add(id, declaration = nil)
      declaration = Proc.new if block_given?

      if declaration.is_a?(Class)
        DSL.send(:define_method, id) do |*args, &block|
          declarations.push declaration.new(*args, &block)
        end
      elsif declaration.is_a?(Proc)
        DSL.send(:define_method, id, &declaration)
      else
        raise ArgumentError, "Unsupported declaration type: #{declaration.class}"
      end
    end
  end
end
```
