### PR TITLE
Fix ruby 2.7 warning for capturing the given block using Proc.new

### DIFF
--- a/lib/clowne/cloner.rb
+++ b/lib/clowne/cloner.rb
@@ -44,7 +44,7 @@ module Clowne # :nodoc: all
       end
 
       # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
-      def call(object, **options)
+      def call(object, **options, &block)
         raise(UnprocessableSourceError, "Nil is not cloneable object") if object.nil?
 
         options = Clowne::Utils::Options.new(options)
@@ -59,7 +59,7 @@ module Clowne # :nodoc: all
             plan_with_traits(options.traits, current_adapter: current_adapter)
           end
 
-        plan = Clowne::Planner.enhance(plan, Proc.new) if block_given?
+        plan = Clowne::Planner.enhance(plan, block) if block
 
         plan = Clowne::Planner.filter_declarations(plan, options.only)
 

--- a/lib/clowne/declarations/after_clone.rb
+++ b/lib/clowne/declarations/after_clone.rb
@@ -5,10 +5,10 @@ module Clowne
     class AfterClone < Base # :nodoc: all
       attr_reader :block
 
-      def initialize
-        raise ArgumentError, "Block is required for after_clone" unless block_given?
+      def initialize(&block)
+        raise ArgumentError, "Block is required for after_clone" unless block
 
-        @block = Proc.new
+        @block = block
       end
 
       def compile(plan)

--- a/lib/clowne/declarations/after_persist.rb
+++ b/lib/clowne/declarations/after_persist.rb
@@ -5,10 +5,10 @@ module Clowne
     class AfterPersist < Base # :nodoc: all
       attr_reader :block
 
-      def initialize
-        raise ArgumentError, "Block is required for after_persist" unless block_given?
+      def initialize(&block)
+        raise ArgumentError, "Block is required for after_persist" unless block
 
-        @block = Proc.new
+        @block = block
       end
 
       def compile(plan)

--- a/lib/clowne/declarations/finalize.rb
+++ b/lib/clowne/declarations/finalize.rb
@@ -5,10 +5,10 @@ module Clowne
     class Finalize < Base # :nodoc: all
       attr_reader :block
 
-      def initialize
-        raise ArgumentError, "Block is required for finalize" unless block_given?
+      def initialize(&block)
+        raise ArgumentError, "Block is required for finalize" unless block
 
-        @block = Proc.new
+        @block = block
       end
 
       def compile(plan)

--- a/lib/clowne/declarations/init_as.rb
+++ b/lib/clowne/declarations/init_as.rb
@@ -5,10 +5,10 @@ module Clowne
     class InitAs < Base # :nodoc: all
       attr_reader :block
 
-      def initialize
-        raise ArgumentError, "Block is required for init_as" unless block_given?
+      def initialize(&block)
+        raise ArgumentError, "Block is required for init_as" unless block
 
-        @block = Proc.new
+        @block = block
       end
 
       def compile(plan)

--- a/spec/clowne/declarations/after_clone_spec.rb
+++ b/spec/clowne/declarations/after_clone_spec.rb
@@ -1,0 +1,19 @@
+describe Clowne::Declarations::AfterClone do
+  describe ".new" do
+    context "with block" do
+      it "works" do
+        declaration = described_class.new { 'some block' }
+        expect(declaration.block).to be_instance_of(Proc)
+      end
+    end
+
+    context "when block has not passed" do
+      it "raise ArgumentError" do
+        expect { described_class.new }.to raise_error(
+          ArgumentError,
+          "Block is required for after_clone"
+        )
+      end
+    end
+  end
+end

--- a/spec/clowne/declarations/after_persist_spec.rb
+++ b/spec/clowne/declarations/after_persist_spec.rb
@@ -1,0 +1,19 @@
+describe Clowne::Declarations::AfterPersist do
+  describe ".new" do
+    context "with block" do
+      it "works" do
+        declaration = described_class.new { 'some block' }
+        expect(declaration.block).to be_instance_of(Proc)
+      end
+    end
+
+    context "when block has not passed" do
+      it "raise ArgumentError" do
+        expect { described_class.new }.to raise_error(
+          ArgumentError,
+          "Block is required for after_persist"
+        )
+      end
+    end
+  end
+end

--- a/spec/clowne/declarations/finalize_spec.rb
+++ b/spec/clowne/declarations/finalize_spec.rb
@@ -1,0 +1,19 @@
+describe Clowne::Declarations::Finalize do
+  describe ".new" do
+    context "with block" do
+      it "works" do
+        declaration = described_class.new { 'some block' }
+        expect(declaration.block).to be_instance_of(Proc)
+      end
+    end
+
+    context "when block has not passed" do
+      it "raise ArgumentError" do
+        expect { described_class.new }.to raise_error(
+          ArgumentError,
+          "Block is required for finalize"
+        )
+      end
+    end
+  end
+end

--- a/spec/clowne/declarations/init_as_spec.rb
+++ b/spec/clowne/declarations/init_as_spec.rb
@@ -1,0 +1,19 @@
+describe Clowne::Declarations::InitAs do
+  describe ".new" do
+    context "with block" do
+      it "works" do
+        declaration = described_class.new { 'some block' }
+        expect(declaration.block).to be_instance_of(Proc)
+      end
+    end
+
+    context "when block has not passed" do
+      it "raise ArgumentError" do
+        expect { described_class.new }.to raise_error(
+          ArgumentError,
+          "Block is required for init_as"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello guys!
My application is using Ruby 2.7 and I am getting annoying warnings for capturing block using `Proc.new`.
I think my PR will resolve it.
Let me know if something wrong.
Thank you!