### PR TITLE
Ruby 3.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "sqlite3", "~> 1.4.1", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", "~> 50.0", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 
-gem "activerecord", ">= 5.2", "< 6.2.0"
+gem "activerecord", ">= 6.0", "< 6.2.0"
 gem "sequel", ">= 5.0"
 gem "simplecov"
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "sqlite3", "~> 1.4.1", platform: :ruby
 gem "activerecord-jdbcsqlite3-adapter", "~> 50.0", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 
-gem "activerecord", "~> 5.2"
+gem "activerecord", ">= 5.2", "< 6.2.0"
 gem "sequel", ">= 5.0"
 gem "simplecov"
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class UserCloner < Clowne::Cloner
   nullify :login
 
   # params here is an arbitrary Hash passed into cloner
-  finalize do |_source, record, params|
+  finalize do |_source, record, **params|
     record.email = params[:email]
   end
 end

--- a/clowne.gemspec
+++ b/clowne.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'factory_bot', '~> 4.8'
+  spec.add_development_dependency 'factory_bot', '~> 5'
   spec.add_development_dependency 'rubocop', '~> 0.75.0'
   spec.add_development_dependency 'rubocop-md', '~> 0.3.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.36.0'

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ class UserCloner < Clowne::Cloner
   nullify :login
 
   # params here is an arbitrary Hash passed into cloner
-  finalize do |_source, record, params|
+  finalize do |_source, record, **params|
     record.email = params[:email]
   end
 end

--- a/docs/after_persist.md
+++ b/docs/after_persist.md
@@ -30,7 +30,7 @@ class UserCloner < Clowne::Cloner
 
   after_persist do |origin, clone, mapper:, **|
     cloned_bio = mapper.clone_of(origin.bio)
-    clone.update_attributes(bio_id: cloned_bio.id)
+    clone.update(bio_id: cloned_bio.id)
   end
 end
 
@@ -50,7 +50,7 @@ end
 user = User.create
 posts = Array.new(3) { Post.create(user: user) }
 bio = posts.sample
-user.update_attributes(bio_id: bio.id)
+user.update(bio_id: bio.id)
 
 operation = UserCloner.call(user, run_job: true)
 # => <#Clowne::Utils::Operation ...>

--- a/docs/clone_mapper.md
+++ b/docs/clone_mapper.md
@@ -9,7 +9,7 @@ class UserCloner < Clowne::Cloner
   # ...
   after_persist do |origin, clone, mapper:, **|
     cloned_bio = mapper.clone_of(origin.bio)
-    clone.update_attributes(bio_id: cloned_bio.id)
+    clone.update(bio_id: cloned_bio.id)
   end
 end
 ```

--- a/docs/finalize.md
+++ b/docs/finalize.md
@@ -4,12 +4,12 @@ To apply custom transformations to the cloned record, you can use the `finalize`
 
 ```ruby
 class UserCloner < Clowne::Cloner
-  finalize do |_source, record, _params|
+  finalize do |_source, record, **_params|
     record.name = "This is copy!"
   end
 
   trait :change_email do
-    finalize do |_source, record, params|
+    finalize do |_source, record, **params|
       record.email = params[:email]
     end
   end

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -81,7 +81,7 @@ class UserCloner < Clowne::Cloner
   nullify :login
 
   # params here is an arbitrary Hash passed into cloner
-  finalize do |_source, record, params|
+  finalize do |_source, record, **params|
     record.email = params[:email]
   end
 end

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -11,7 +11,7 @@ class UserCloner < Clowne::Cloner
   nullify :email
 
   after_persist do |_origin, cloned, **|
-    cloned.update_attributes(email: "evl-#{cloned.id}.ms")
+    cloned.update(email: "evl-#{cloned.id}.ms")
   end
 end
 
@@ -34,7 +34,7 @@ operation.to_record
 # Call only after_persist callbacks:
 user2 = operation.to_record
 # => <#User id: 2, email: 'evl-2.ms', ...>
-user2.update_attributes(email: "admin@example.com")
+user2.update(email: "admin@example.com")
 # => <#User id: 2, email: 'admin@example.com' ...>
 operation.run_after_persist
 # => <#User id: 2, email: 'evl-2.ms', ...>

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -8,7 +8,7 @@ Example:
 class UserCloner < Clowne::Cloner
   include_association :posts, ->(params) { where(state: params[:state]) }
 
-  finalize do |_source, record, params|
+  finalize do |_source, record, **params|
     record.email = params[:email]
   end
 end
@@ -27,7 +27,7 @@ As result we strongly recommend to use ruby keyword arguments instead of params 
 
 ```ruby
 # Bad
-finalize do |_source, record, params|
+finalize do |_source, record, **params|
   record.email = params[:email]
 end
 
@@ -82,7 +82,7 @@ class UserCloner < Clowne::Cloner
 end
 
 class ProfileCloner < Clowne::Cloner
-  finalize do |_source, record, params|
+  finalize do |_source, record, **params|
     record.jsonb_field = params
   end
 end

--- a/lib/clowne/adapters/active_record/dsl.rb
+++ b/lib/clowne/adapters/active_record/dsl.rb
@@ -6,8 +6,8 @@ module Clowne
     module ActiveRecordDSL
       module InstanceMethods # :nodoc:
         # Shortcut to call class's cloner call with self
-        def clowne(*args, &block)
-          self.class.cloner_class.call(self, *args, &block)
+        def clowne(**args, &block)
+          self.class.cloner_class.call(self, **args, &block)
         end
       end
 

--- a/lib/clowne/adapters/base/association.rb
+++ b/lib/clowne/adapters/base/association.rb
@@ -30,7 +30,7 @@ module Clowne
 
         def clone_one(child)
           cloner = cloner_for(child)
-          cloner ? cloner.call(child, cloner_options) : dup_record(child)
+          cloner ? cloner.call(child, **cloner_options) : dup_record(child)
         end
 
         def with_scope

--- a/lib/clowne/declarations.rb
+++ b/lib/clowne/declarations.rb
@@ -11,8 +11,8 @@ module Clowne
       declaration = block if block_given?
 
       if declaration.is_a?(Class)
-        DSL.send(:define_method, id) do |*args, &inner_block|
-          declarations.push declaration.new(*args, &inner_block)
+        DSL.send(:define_method, id) do |*args, **hargs, &inner_block|
+          declarations.push declaration.new(*args, **hargs, &inner_block)
         end
       elsif declaration.is_a?(Proc)
         DSL.send(:define_method, id, &declaration)

--- a/lib/clowne/declarations/after_clone.rb
+++ b/lib/clowne/declarations/after_clone.rb
@@ -5,7 +5,7 @@ module Clowne
     class AfterClone < Base # :nodoc: all
       attr_reader :block
 
-      def initialize(&block)
+      def initialize(*, &block)
         raise ArgumentError, "Block is required for after_clone" unless block
 
         @block = block

--- a/lib/clowne/declarations/after_persist.rb
+++ b/lib/clowne/declarations/after_persist.rb
@@ -5,7 +5,7 @@ module Clowne
     class AfterPersist < Base # :nodoc: all
       attr_reader :block
 
-      def initialize(&block)
+      def initialize(*, &block)
         raise ArgumentError, "Block is required for after_persist" unless block
 
         @block = block

--- a/lib/clowne/declarations/exclude_association.rb
+++ b/lib/clowne/declarations/exclude_association.rb
@@ -5,7 +5,7 @@ module Clowne
     class ExcludeAssociation < Base # :nodoc: all
       attr_accessor :name
 
-      def initialize(name)
+      def initialize(name, **)
         @name = name.to_sym
       end
 

--- a/lib/clowne/declarations/finalize.rb
+++ b/lib/clowne/declarations/finalize.rb
@@ -5,7 +5,7 @@ module Clowne
     class Finalize < Base # :nodoc: all
       attr_reader :block
 
-      def initialize(&block)
+      def initialize(*, &block)
         raise ArgumentError, "Block is required for finalize" unless block
 
         @block = block

--- a/lib/clowne/declarations/init_as.rb
+++ b/lib/clowne/declarations/init_as.rb
@@ -5,7 +5,7 @@ module Clowne
     class InitAs < Base # :nodoc: all
       attr_reader :block
 
-      def initialize(&block)
+      def initialize(*, &block)
         raise ArgumentError, "Block is required for init_as" unless block
 
         @block = block

--- a/lib/clowne/declarations/nullify.rb
+++ b/lib/clowne/declarations/nullify.rb
@@ -5,7 +5,7 @@ module Clowne
     class Nullify < Base # :nodoc: all
       attr_reader :attributes
 
-      def initialize(*attributes)
+      def initialize(*attributes, **)
         raise ArgumentError, "At least one attribute required" if attributes.empty?
 
         @attributes = attributes

--- a/lib/clowne/resolvers/after_persist.rb
+++ b/lib/clowne/resolvers/after_persist.rb
@@ -8,7 +8,7 @@ module Clowne
         params ||= {}
         operation.add_after_persist(
           proc do
-            declaration.block.call(source, record, params.merge(mapper: operation.mapper))
+            declaration.block.call(source, record, **params.merge(mapper: operation.mapper))
           end
         )
         record

--- a/lib/clowne/resolvers/finalize.rb
+++ b/lib/clowne/resolvers/finalize.rb
@@ -4,7 +4,7 @@ module Clowne
   class Resolvers
     module Finalize # :nodoc: all
       def self.call(source, record, declaration, params:, **_options)
-        declaration.block.call(source, record, params)
+        declaration.block.call(source, record, **params)
         record
       end
     end

--- a/spec/clowne/adapters/active_record/associations/belongs_to_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/belongs_to_spec.rb
@@ -28,7 +28,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::BelongsTo,
     context "with custom cloner" do
       let(:topic_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |_source, record, params|
+          finalize do |_source, record, **params|
             record.title += params.fetch(:suffix, "-2")
             record.description += " (Cloned)"
           end

--- a/spec/clowne/adapters/active_record/associations/has_and_belongs_to_many_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_and_belongs_to_many_spec.rb
@@ -40,7 +40,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HABTM, :cleanup, adapter:
     context "with custom cloner" do
       let(:tag_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |_source, record, params|
+          finalize do |_source, record, **params|
             record.value += params.fetch(:suffix, "-2")
           end
 

--- a/spec/clowne/adapters/active_record/associations/has_many_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_many_spec.rb
@@ -15,7 +15,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
   before(:all) do
     module AR
       class PostCloner < Clowne::Cloner
-        finalize do |_source, record, params|
+        finalize do |_source, record, **params|
           record.topic_id = params[:topic_id] if params[:topic_id]
         end
 
@@ -138,7 +138,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasMany, :cleanup, adapte
 
       let(:post_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |source, record, _params|
+          finalize do |source, record, **_params|
             record.title = "Copy of #{source.title}"
           end
         end

--- a/spec/clowne/adapters/active_record/associations/has_one_spec.rb
+++ b/spec/clowne/adapters/active_record/associations/has_one_spec.rb
@@ -17,7 +17,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
   before(:all) do
     module AR
       class ImageCloner < Clowne::Cloner
-        finalize do |source, record, params|
+        finalize do |source, record, **params|
           record.created_at = source.created_at if params[:include_timestamps]
         end
 
@@ -33,7 +33,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
       end
 
       class PreviewImageCloner < Clowne::Cloner
-        finalize do |source, record, params|
+        finalize do |source, record, **params|
           record.created_at = source.created_at if params[:include_timestamps]
         end
 
@@ -119,7 +119,7 @@ describe Clowne::Adapters::ActiveRecord::Associations::HasOne, :cleanup, adapter
     context "with custom cloner" do
       let(:image_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |source, record, _params|
+          finalize do |source, record, **_params|
             record.title = "Copy of #{source.title}"
           end
         end

--- a/spec/clowne/adapters/sequel/associations/many_to_many_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/many_to_many_spec.rb
@@ -41,7 +41,7 @@ describe Clowne::Adapters::Sequel::Associations::ManyToMany, :cleanup, adapter: 
     context "with custom cloner" do
       let(:tag_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |_source, record, params|
+          finalize do |_source, record, **params|
             record.value += params.fetch(:suffix, "-2")
           end
 

--- a/spec/clowne/adapters/sequel/associations/one_to_many_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/one_to_many_spec.rb
@@ -17,7 +17,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
       class PostCloner < Clowne::Cloner
         include_associations :image, :tags
 
-        finalize do |_source, record, params|
+        finalize do |_source, record, **params|
           record.topic_id = params[:topic_id] if params[:topic_id]
         end
 
@@ -171,7 +171,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToMany, :cleanup, adapter: :
 
       let(:post_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |source, record, _params|
+          finalize do |source, record, **_params|
             record.title = "Copy of #{source.title}"
           end
         end

--- a/spec/clowne/adapters/sequel/associations/one_to_one_spec.rb
+++ b/spec/clowne/adapters/sequel/associations/one_to_one_spec.rb
@@ -17,7 +17,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
   before(:all) do
     module Sequel
       class ImageCloner < Clowne::Cloner
-        finalize do |source, record, params|
+        finalize do |source, record, **params|
           record.created_at = source.created_at if params[:include_timestamps]
         end
 
@@ -33,7 +33,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
       end
 
       class PreviewImageCloner < Clowne::Cloner
-        finalize do |source, record, params|
+        finalize do |source, record, **params|
           record.created_at = source.created_at if params[:include_timestamps]
         end
 
@@ -114,7 +114,7 @@ describe Clowne::Adapters::Sequel::Associations::OneToOne, :cleanup, adapter: :s
     context "with custom cloner" do
       let(:image_cloner) do
         Class.new(Clowne::Cloner) do
-          finalize do |source, record, _params|
+          finalize do |source, record, **_params|
             record.title = "Copy of #{source.title}"
           end
         end

--- a/spec/clowne/cloner_spec.rb
+++ b/spec/clowne/cloner_spec.rb
@@ -12,7 +12,7 @@ describe Clowne::Cloner do
 
       nullify :title, :description
 
-      finalize do |_source, _record, _params|
+      finalize do |_source, _record, **_params|
         1 + 1
       end
 

--- a/spec/clowne/integrations/active_record_dsl_spec.rb
+++ b/spec/clowne/integrations/active_record_dsl_spec.rb
@@ -26,7 +26,7 @@ describe "AR DSl", :cleandb do
         clowne_config do
           include_association :image
 
-          finalize do |source, record, params|
+          finalize do |source, record, **params|
             record.title = params[:title] || "Clone of #{source.title}"
           end
         end

--- a/spec/clowne/integrations/active_record_spec.rb
+++ b/spec/clowne/integrations/active_record_spec.rb
@@ -12,7 +12,7 @@ describe "AR adapter", :cleanup, adapter: :active_record, transactional: :active
       end
 
       class BasePostCloner < Clowne::Cloner
-        finalize do |_source, record, params|
+        finalize do |_source, record, **params|
           record.contents = params[:post_contents] if params[:post_contents].present?
         end
       end

--- a/spec/clowne/integrations/after_persist_spec.rb
+++ b/spec/clowne/integrations/after_persist_spec.rb
@@ -6,7 +6,7 @@ describe "Post Processing", :cleanup, adapter: :active_record, transactional: :a
 
         after_persist do |origin, clone, mapper:|
           cloned_image = mapper.clone_of(origin.image)
-          clone.update_attributes(image_id: cloned_image.id)
+          clone.update(image_id: cloned_image.id)
         end
       end
 
@@ -41,7 +41,7 @@ describe "Post Processing", :cleanup, adapter: :active_record, transactional: :a
 
   before do
     images.each { |image| create(:preview_image, image: image) }
-    topic.update_attributes(image_id: topic_image.id)
+    topic.update(image_id: topic_image.id)
   end
 
   describe 'The main idea of "after persist" feature is a possibility

--- a/spec/clowne/integrations/sequel_spec.rb
+++ b/spec/clowne/integrations/sequel_spec.rb
@@ -18,7 +18,7 @@ describe "Sequel adapter", :cleanup, adapter: :sequel, transactional: :sequel do
       end
 
       class BasePostCloner < Clowne::Cloner
-        finalize do |_source, record, params|
+        finalize do |_source, record, **params|
           record.contents = params[:post_contents] if params[:post_contents].present?
         end
       end

--- a/spec/clowne/resolvers/after_persist_spec.rb
+++ b/spec/clowne/resolvers/after_persist_spec.rb
@@ -6,7 +6,7 @@ describe Clowne::Resolvers::AfterPersist do
     let(:params) { {} }
     let(:block) do
       proc do |source, record, mapper:|
-        record.update_attributes(email: "admin#{record.id}@#{mapper.clone_of(source)}")
+        record.update(email: "admin#{record.id}@#{mapper.clone_of(source)}")
       end
     end
 


### PR DESCRIPTION
I started working on Ruby 3 compatibility to fix issue #57 and as I thought it's mostly about fixing positional and keyword arguments.

I got almost all the tests to pass except when related to these two block declarations:

```ruby
# 1st declaration
finalize do |_source, record, params|
end

# 2nd declaration
finalize do |_source, record, email:, **|
end
```

I cannot figure out how to support both these declarations with Ruby 3 and keep backward compatibility with prior versions.

The second declaration will not work with Ruby 3 as it is. It can be fixed by adding a double splat operator (`**`) to the params hash when calling the finalize block:

```ruby
module Clowne
  class Resolvers
    module Finalize # :nodoc: all
      def self.call(source, record, declaration, params:, **_options)
        declaration.block.call(source, record, **params)
        record
      end
    end
  end
end
```

But then this breaks the first declaration... I feel like I'm almost there. I hope you can help me figure out the rest!