### PR TITLE
Allow access to the operation mapper in after_clone

### DIFF
--- a/lib/clowne/resolvers/after_clone.rb
+++ b/lib/clowne/resolvers/after_clone.rb
@@ -5,9 +5,10 @@ module Clowne
     module AfterClone # :nodoc: all
       def self.call(source, record, declaration, params:, **_options)
         operation = Clowne::Utils::Operation.current
+        params ||= {}
         operation.add_after_clone(
           proc do
-            declaration.block.call(source, record, params)
+            declaration.block.call(source, record, **params.merge(mapper: operation.mapper))
           end
         )
         record

--- a/spec/clowne/resolvers/after_clone_spec.rb
+++ b/spec/clowne/resolvers/after_clone_spec.rb
@@ -5,8 +5,8 @@ describe Clowne::Resolvers::AfterClone do
     let(:source) { AR::User.create(email: "admin@example.com") }
     let(:params) { {} }
     let(:block) do
-      proc do |_source, record|
-        record.email = "admin-cloned@example.com"
+      proc do |source, record, mapper:|
+        record.email = "admin@#{mapper.clone_of(source)}"
       end
     end
 
@@ -15,13 +15,14 @@ describe Clowne::Resolvers::AfterClone do
       operation = Clowne::Utils::Operation.wrap do
         described_class.call(source, record, declaration, params: params)
       end
+      operation.add_mapping(source, "example-cloned.com")
       operation.persist
       operation.to_record
     end
 
     it "execute after_clone block" do
       expect(result).to be_a(AR::User)
-      expect(result.email).to eq("admin-cloned@example.com")
+      expect(result.email).to eq("admin@example-cloned.com")
     end
 
     context "with params" do


### PR DESCRIPTION
Hey! This is a revival of https://github.com/clowne-rb/clowne/pull/48, rebased on master and with a test to ensure it works. I have a complex case that needed access to the mapper before the operation was persisted. I had a go at doing an integration test as suggested by @ssnickolay in the other PR, but I was not able to create something resembling my real use case. Thus I decided to add a simple test to ensure the mapper works in `after_clone`.

I added @tuanmai as co-author, since he created the first PR.

closes #48